### PR TITLE
Feat: Slack 연동 및 에러 시 알림 전송 기능 추가 (#9)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	// Swagger
 	implementation "io.springfox:springfox-boot-starter:3.0.0"

--- a/src/main/java/com/dnd/Exercise/global/config/WebConfig.java
+++ b/src/main/java/com/dnd/Exercise/global/config/WebConfig.java
@@ -1,0 +1,18 @@
+package com.dnd.Exercise.global.config;
+
+import com.dnd.Exercise.global.slack.RequestStorage;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig{
+
+    @Bean
+    @Scope(value = "request", proxyMode = ScopedProxyMode.TARGET_CLASS)
+    public RequestStorage requestStorage() {
+        return new RequestStorage();
+    }
+}

--- a/src/main/java/com/dnd/Exercise/global/error/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/dnd/Exercise/global/error/handler/GlobalExceptionHandler.java
@@ -3,6 +3,8 @@ package com.dnd.Exercise.global.error.handler;
 import com.dnd.Exercise.global.error.dto.ErrorCode;
 import com.dnd.Exercise.global.error.dto.ErrorResponse;
 import com.dnd.Exercise.global.error.exception.BusinessException;
+import com.dnd.Exercise.global.slack.SlackAlarm;
+import com.dnd.Exercise.global.slack.SlackAlarmErrorLevel;
 import javax.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -12,9 +14,10 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
-@ControllerAdvice
+@RestControllerAdvice
 @Slf4j
 public class GlobalExceptionHandler {
 
@@ -71,7 +74,7 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, errorCode.getStatus());
     }
 
-
+    @SlackAlarm(level = SlackAlarmErrorLevel.ERROR)
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(
             Exception e, HttpServletRequest request) {

--- a/src/main/java/com/dnd/Exercise/global/filter/ServletWrappingFilter.java
+++ b/src/main/java/com/dnd/Exercise/global/filter/ServletWrappingFilter.java
@@ -1,0 +1,31 @@
+package com.dnd.Exercise.global.filter;
+
+import com.dnd.Exercise.global.slack.RequestStorage;
+import java.io.IOException;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Component
+public class ServletWrappingFilter extends OncePerRequestFilter {
+
+    private final RequestStorage requestStorage;
+
+    public ServletWrappingFilter(RequestStorage requestStorage) {
+        this.requestStorage = requestStorage;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+
+        ContentCachingRequestWrapper wrappedRequest = new ContentCachingRequestWrapper(request);
+        requestStorage.set(wrappedRequest);
+
+        filterChain.doFilter(wrappedRequest, response);
+    }
+}

--- a/src/main/java/com/dnd/Exercise/global/slack/RequestStorage.java
+++ b/src/main/java/com/dnd/Exercise/global/slack/RequestStorage.java
@@ -1,0 +1,16 @@
+package com.dnd.Exercise.global.slack;
+
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+public class RequestStorage {
+
+    private ContentCachingRequestWrapper request;
+
+    public void set(ContentCachingRequestWrapper request) {
+        this.request = request;
+    }
+
+    public ContentCachingRequestWrapper get() {
+        return request;
+    }
+}

--- a/src/main/java/com/dnd/Exercise/global/slack/SlackAlarm.java
+++ b/src/main/java/com/dnd/Exercise/global/slack/SlackAlarm.java
@@ -1,0 +1,14 @@
+package com.dnd.Exercise.global.slack;
+
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SlackAlarm {
+
+    SlackAlarmErrorLevel level() default SlackAlarmErrorLevel.WARN;
+}

--- a/src/main/java/com/dnd/Exercise/global/slack/SlackAlarmErrorLevel.java
+++ b/src/main/java/com/dnd/Exercise/global/slack/SlackAlarmErrorLevel.java
@@ -1,0 +1,9 @@
+package com.dnd.Exercise.global.slack;
+
+public enum SlackAlarmErrorLevel {
+    TRACE,
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR
+}

--- a/src/main/java/com/dnd/Exercise/global/slack/SlackMessageAop.java
+++ b/src/main/java/com/dnd/Exercise/global/slack/SlackMessageAop.java
@@ -1,0 +1,48 @@
+package com.dnd.Exercise.global.slack;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+@Profile({"prod", "dev"})
+@RequiredArgsConstructor
+public class SlackMessageAop {
+
+    private final RequestStorage requestStorage;
+    private final SlackMessageGenerator slackMessageGenerator;
+    private final SlackMessageSender slackMessageSender;
+
+    @Before("@annotation(com.dnd.Exercise.global.slack.SlackAlarm)")
+    public void appendExceptionToResponseBody(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+
+        if (!validateIsException(args)) {
+            return;
+        }
+
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        SlackAlarm annotation = signature.getMethod().getAnnotation(SlackAlarm.class);
+        SlackAlarmErrorLevel level = annotation.level();
+
+        String message = slackMessageGenerator
+                .generate(requestStorage.get(), (Exception) args[0], level);
+
+        slackMessageSender.send(message);
+    }
+
+    private boolean validateIsException(Object[] args) {
+        if (!(args[0] instanceof Exception)) {
+            log.warn("[SlackAlarm] argument is not Exception");
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/dnd/Exercise/global/slack/SlackMessageGenerator.java
+++ b/src/main/java/com/dnd/Exercise/global/slack/SlackMessageGenerator.java
@@ -1,0 +1,104 @@
+package com.dnd.Exercise.global.slack;
+
+import static java.util.stream.Collectors.joining;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+
+@Component
+public class SlackMessageGenerator {
+
+    private static final String EXTRACTION_ERROR_MESSAGE = "메세지를 추출하는데 오류가 생겼습니다.\nmessagee : %s";
+    private static final String EXCEPTION_MESSAGE_FORMAT = "_%s_ %s.%s:%d - %s";
+    private static final String SLACK_MESSAGE_FORMAT = "*[%s]* %s\n*[ERROR LOG]*\n%s\n\n*[REQUEST_INFORMATION]*\n%s %s\n%s\n\n%s";
+    private static final String EMPTY_BODY_MESSAGE = "{BODY IS EMPTY}";
+
+    private final Environment environment;
+
+    public SlackMessageGenerator(Environment environment) {
+        this.environment = environment;
+    }
+
+    public String generate(ContentCachingRequestWrapper request,
+            Exception exception,
+            SlackAlarmErrorLevel level) {
+        try {
+            String profile = getProfile();
+            String currentTime = getCurrentTime();
+            String method = request.getMethod();
+            String requestURI = request.getRequestURI();
+            String headers = extractHeaders(request);
+            String body = getBody(request);
+            String exceptionMessage = extractExceptionMessage(exception, level);
+
+            return toMessage(profile, currentTime, exceptionMessage, method, requestURI, headers, body);
+        } catch (Exception e) {
+            return String.format(EXTRACTION_ERROR_MESSAGE, e.getMessage());
+        }
+    }
+
+    private String getProfile() {
+        return String.join(",", environment.getActiveProfiles()).toUpperCase();
+    }
+
+    private String getCurrentTime() {
+        return LocalDateTime.now().toString();
+    }
+
+    private String extractHeaders(ContentCachingRequestWrapper request) {
+        Enumeration<String> headerNames = request.getHeaderNames();
+
+        Map<String, String> values = new HashMap<>();
+
+        while (headerNames.hasMoreElements()) {
+            String headerName = headerNames.nextElement();
+            values.put(headerName, request.getHeader(headerName));
+        }
+
+        return values.entrySet().stream()
+                .map(e -> e.getKey() + ":" + e.getValue())
+                .collect(joining("\n"));
+    }
+
+    private String getBody(ContentCachingRequestWrapper request) {
+        String body = new String(request.getContentAsByteArray());
+        if (body.isEmpty()) {
+            body = EMPTY_BODY_MESSAGE;
+        }
+        return body;
+    }
+
+    private String extractExceptionMessage(Exception e, SlackAlarmErrorLevel level) {
+        StackTraceElement stackTrace = e.getStackTrace()[0];
+        String className = stackTrace.getClassName();
+        int lineNumber = stackTrace.getLineNumber();
+        String methodName = stackTrace.getMethodName();
+
+        String message = e.getMessage();
+
+        if (Objects.isNull(message)) {
+            return Arrays.stream(e.getStackTrace())
+                    .map(StackTraceElement::toString)
+                    .collect(joining("\n"));
+        }
+
+        return String.format(EXCEPTION_MESSAGE_FORMAT, level.name(), className,
+                methodName, lineNumber, message);
+    }
+
+
+    private String toMessage(String profile, String currentTime, String errorMessage,
+            String method, String requestURI, String headers, String body) {
+        return String.format(
+                SLACK_MESSAGE_FORMAT, profile, currentTime,
+                errorMessage, method, requestURI, headers, body
+        );
+    }
+}

--- a/src/main/java/com/dnd/Exercise/global/slack/SlackMessageSender.java
+++ b/src/main/java/com/dnd/Exercise/global/slack/SlackMessageSender.java
@@ -1,0 +1,47 @@
+package com.dnd.Exercise.global.slack;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Component
+@Slf4j
+public class SlackMessageSender {
+
+    private final String SLACK_LOGGER_WEBHOOK_URI;
+    public final ObjectMapper objectMapper;
+
+    public SlackMessageSender(
+            ObjectMapper objectMapper,
+            @Value("${slack.webhook.uri}") String slack_webhook_uri) {
+        this.objectMapper = objectMapper;
+        SLACK_LOGGER_WEBHOOK_URI = slack_webhook_uri;
+    }
+
+    public void send(String message) {
+        WebClient.create(SLACK_LOGGER_WEBHOOK_URI)
+                .post()
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(toJson(message))
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+    }
+
+    private String toJson(String message) {
+        try {
+            Map<String, String> values = new HashMap<>();
+            values.put("text", message);
+
+            return objectMapper.writeValueAsString(values);
+        } catch (JsonProcessingException ignored) {
+        }
+        return "{\"text\" : \"슬랙으로 보낼 데이터를 제이슨으로 변경하는데 에러가 발생함.\"}";
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- SlackAlarm 애노테이션을 포인트 컷으로 하는 AOP를 사용해서 에러 발생 시 슬랙으로 알림 전송

## 📋 변경 사항
- 일회성 읽기만을 제공하는 Request의 데이터를 캐싱하여 여러번 읽을 수 있도록 하기 위해 Request를 wrapping 해주는 필터를 적용했습니다 - 에러 메시지 추출 용도
    - RequestStorage를 Request Scope으로 설정하였고 ApplicationContext를 load하는 시점에서 RequestStorage를 주입받기 위해 proxyMode를 설정해주었습니다.
- SlackMessageGenerator를 사용하여 메시지를 생성하고 SlackMessageSender를 통해서 슬랙으로 메시지를 보냅니다.
    - incoming Webhook을 사용하였으며 WebClient를 사용하기 위해 Webflux 의존성을 추가했습니다.

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 📸 ScreenShot
<img width="1032" alt="image" src="https://github.com/dnd-side-project/dnd-9th-9-backend/assets/92415841/d0cfb2ba-447f-4c94-b4c1-0406123ab754">

## 연결된 이슈 Close
close #9 
