### PR TITLE
Fix: Match 엔티티 컬럼 추가 및 오타 수정, NotificationType - MatchType 분리 (#12)

### DIFF
--- a/src/main/java/com/dnd/Exercise/domain/match/entity/Match.java
+++ b/src/main/java/com/dnd/Exercise/domain/match/entity/Match.java
@@ -55,6 +55,9 @@ public class Match {
     @Enumerated(EnumType.STRING)
     private MatchType matchType;
 
+    @Enumerated(EnumType.STRING)
+    private SkillLevel skillLevel;
+
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "opponent_id")
     private Match opponent;

--- a/src/main/java/com/dnd/Exercise/domain/match/entity/Match.java
+++ b/src/main/java/com/dnd/Exercise/domain/match/entity/Match.java
@@ -2,7 +2,6 @@ package com.dnd.Exercise.domain.match.entity;
 
 import static javax.persistence.FetchType.LAZY;
 
-import com.dnd.Exercise.domain.notification.entity.MatchType;
 import java.time.LocalDate;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -25,7 +24,7 @@ public class Match {
 
     private String name;
 
-    private String profile_img;
+    private String profileImg;
 
     @Enumerated(EnumType.STRING)
     private Strength strength;
@@ -39,8 +38,6 @@ public class Match {
 
     private int currentSize;
 
-    private Boolean isActive;
-
     @Enumerated(EnumType.STRING)
     private Period period;
 
@@ -49,7 +46,7 @@ public class Match {
     private Long leaderId;
 
     @Enumerated(EnumType.STRING)
-    private MatchStatus MatchStatus;
+    private MatchStatus matchStatus;
 
     private LocalDate startDate;
 

--- a/src/main/java/com/dnd/Exercise/domain/match/entity/MatchStatus.java
+++ b/src/main/java/com/dnd/Exercise/domain/match/entity/MatchStatus.java
@@ -1,5 +1,5 @@
 package com.dnd.Exercise.domain.match.entity;
 
 public enum MatchStatus {
-    IN_PROGRESS, RECRUITING, COMPLETED
+    RECRUITING, IN_PROGRESS, COMPLETED
 }

--- a/src/main/java/com/dnd/Exercise/domain/match/entity/MatchType.java
+++ b/src/main/java/com/dnd/Exercise/domain/match/entity/MatchType.java
@@ -1,0 +1,5 @@
+package com.dnd.Exercise.domain.match.entity;
+
+public enum MatchType {
+    DUEL, TEAM_BATTLE, TEAM
+}

--- a/src/main/java/com/dnd/Exercise/domain/match/entity/SkillLevel.java
+++ b/src/main/java/com/dnd/Exercise/domain/match/entity/SkillLevel.java
@@ -1,0 +1,8 @@
+package com.dnd.Exercise.domain.match.entity;
+
+public enum SkillLevel {
+    BEGINNER,
+    INTERMEDIATE,
+    ADVANCED_INTERMEDIATE,
+    EXPERT
+}

--- a/src/main/java/com/dnd/Exercise/domain/matchEntry/entity/MatchEntry.java
+++ b/src/main/java/com/dnd/Exercise/domain/matchEntry/entity/MatchEntry.java
@@ -3,7 +3,7 @@ package com.dnd.Exercise.domain.matchEntry.entity;
 import static javax.persistence.FetchType.*;
 
 import com.dnd.Exercise.domain.match.entity.Match;
-import com.dnd.Exercise.domain.notification.entity.MatchType;
+import com.dnd.Exercise.domain.match.entity.MatchType;
 import com.dnd.Exercise.domain.user.entity.User;
 import javax.persistence.Column;
 import javax.persistence.Entity;

--- a/src/main/java/com/dnd/Exercise/domain/notification/entity/Notification.java
+++ b/src/main/java/com/dnd/Exercise/domain/notification/entity/Notification.java
@@ -30,7 +30,7 @@ public class Notification extends BaseEntity {
     private Boolean isRead;
 
     @Enumerated(EnumType.STRING)
-    private MatchType matchType;
+    private NotificationType notificationType;
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/com/dnd/Exercise/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/dnd/Exercise/domain/notification/entity/NotificationType.java
@@ -1,5 +1,5 @@
 package com.dnd.Exercise.domain.notification.entity;
 
-public enum MatchType {
+public enum NotificationType {
     TEAM, DUEL, USER
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- Match 엔티티 컬럼 추가 및 오타 수정
- NotificationType - MatchType 분리

## 📋 변경 사항
- 오타 수정
    - profile_img -> profileImg
    - MatchStatus -> matchStatus
- SkillLevel 컬럼 추가
- 기존 MatchType -> NotificationType 변경, MatchType 추가

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 연결된 이슈
#12 
