### PR TITLE
Feat: Swagger api 전달을 위해 '운동기록, 활동링' 관련 컨트롤러 계층과 DTO 구현 (#17)

### DIFF
--- a/src/main/java/com/dnd/Exercise/domain/activityRing/controller/ActivityRingController.java
+++ b/src/main/java/com/dnd/Exercise/domain/activityRing/controller/ActivityRingController.java
@@ -1,0 +1,20 @@
+package com.dnd.Exercise.domain.activityRing.controller;
+
+import com.dnd.Exercise.domain.activityRing.dto.UpdateActivityRingReq;
+import com.dnd.Exercise.global.common.ResponseDto;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Api(tags = "활동링 💫")
+@RestController
+@RequestMapping("/activity-ring")
+public class ActivityRingController {
+
+    @ApiOperation(value = "활동링 정보 업데이트하기 💫", notes = "애플에서 업데이트된 활동링 정보를 반영합니다.")
+    @PostMapping("")
+    public ResponseEntity<String> updateActivityRing(@RequestBody UpdateActivityRingReq updateActivityRingReq) {
+        return ResponseDto.ok("활동링 정보 업데이트 완료");
+    }
+}

--- a/src/main/java/com/dnd/Exercise/domain/activityRing/dto/UpdateActivityRingReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/activityRing/dto/UpdateActivityRingReq.java
@@ -1,0 +1,18 @@
+package com.dnd.Exercise.domain.activityRing.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class UpdateActivityRingReq {
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    private int burnedCalorie;
+}

--- a/src/main/java/com/dnd/Exercise/domain/exercise/controller/ExerciseController.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/controller/ExerciseController.java
@@ -1,0 +1,87 @@
+package com.dnd.Exercise.domain.exercise.controller;
+
+
+import com.dnd.Exercise.domain.exercise.dto.request.PostExerciseByAppleReq;
+import com.dnd.Exercise.domain.exercise.dto.request.PostExerciseByCommonReq;
+import com.dnd.Exercise.domain.exercise.dto.request.UpdateExerciseReq;
+import com.dnd.Exercise.domain.exercise.dto.response.FindAllExerciseDetailsOfDayRes;
+import com.dnd.Exercise.domain.exercise.dto.response.GetCalorieStateRes;
+import com.dnd.Exercise.domain.exercise.dto.response.GetMyExerciseSummaryRes;
+import com.dnd.Exercise.domain.exercise.dto.response.GetRatingExerciseSummaryRes;
+import com.dnd.Exercise.global.common.ResponseDto;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiImplicitParam;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+
+@Api(tags = "운동 기록 (기록하기, 요악, 칼로리 정보) 📝")
+@RestController
+@RequestMapping("/exercise")
+public class ExerciseController {
+
+    @ApiOperation(value = "오늘 하루 나의 모든 운동 상세 기록 불러오기 📝", notes = "개인 운동기록 조회")
+    @ApiImplicitParam(name = "date", value = "오늘 날짜", required = true, dataType = "string")
+    @GetMapping("")
+    public ResponseEntity<FindAllExerciseDetailsOfDayRes> findAllExerciseDetailsOfDay(
+            @DateTimeFormat(pattern = "yyyy-MM-dd")
+            @RequestParam LocalDate date) {
+        return ResponseDto.ok(new FindAllExerciseDetailsOfDayRes());
+    }
+
+    @ApiOperation(value = "매치업 서비스 내에서 운동기록 등록 📝", notes = "")
+    @PostMapping("")
+    public ResponseEntity<String> postExerciseByCommon (@RequestBody PostExerciseByCommonReq postExerciseByCommonReq) {
+        return ResponseDto.ok("운동기록 등록 성공");
+    }
+
+    @ApiOperation(value = "애플 데이터에서 운동기록 등록 📝", notes = "운동 리스트 등록 - getAnchoredWorkouts 리스트를 등록합니다 <br> (애플 측에서 데이터 '수정' 발생한 경우에도 이 api 사용) <br> (request body 의 start/end DateTime 은 말씀해주신대로 yyyy-MM-dd HH:mm:ss String 입니다!)")
+    @PostMapping("/apple-workouts")
+    public ResponseEntity<String> postExerciseByApple (@RequestBody PostExerciseByAppleReq postExerciseByAppleReq) {
+        return ResponseDto.ok("애플 운동기록 등록 성공");
+    }
+
+    @ApiOperation(value = "매치업 서비스 내에서 운동기록 수정 📝", notes = "")
+    @ApiImplicitParam(name = "id", value = "운동 기록 id", required = true, dataType = "long")
+    @PutMapping("/{id}")
+    public ResponseEntity<String> updateExercise (@PathVariable("id") Long exerciseId, @RequestBody UpdateExerciseReq updateExerciseReq) {
+        return ResponseDto.ok("운동기록 수정 성공");
+    }
+
+    @ApiOperation(value = "매치업 서비스 내에서 운동기록 삭제 📝", notes = "")
+    @ApiImplicitParam(name = "id", value = "운동 기록 id", required = true, dataType = "long")
+    @DeleteMapping("/{id}")
+    public ResponseEntity<String> deleteExercise (@PathVariable("id") Long exerciseId) {
+        return ResponseDto.ok("운동기록 삭제 성공");
+    }
+
+    @ApiOperation(value = " 오늘 하루 나의 운동기록 요약 📝", notes = "개인 운동기록 페이지의 <요약> 탭에서 확인 <br> - burnedCalorie 는 애플의 activeEnergyBurned 에 해당합니다.")
+    @ApiImplicitParam(name = "date", value = "오늘 날짜", required = true, dataType = "string")
+    @GetMapping("/my-summary")
+    public ResponseEntity<GetMyExerciseSummaryRes> getMyExerciseSummary (
+            @DateTimeFormat(pattern = "yyyy-MM-dd")
+            @RequestParam LocalDate date) {
+        return ResponseDto.ok(new GetMyExerciseSummaryRes());
+    }
+
+    @ApiOperation(value = " (대결 지표로 사용되는) 나의 하루 기록 요약 📝", notes = "특정 하루에 대한 [기록횟수, 오늘까지의 활동링 달성 횟수, 운동시간, 소모 칼로리] 정보 조회 <br> - '홈화면' 등에서 사용")
+    @ApiImplicitParam(name = "date", value = "오늘 날짜", required = true, dataType = "string")
+    @GetMapping("/rating-summary")
+    public ResponseEntity<GetRatingExerciseSummaryRes> getRatingExerciseSummary (
+            @DateTimeFormat(pattern = "yyyy-MM-dd")
+            @RequestParam LocalDate date) {
+        return ResponseDto.ok(new GetRatingExerciseSummaryRes());
+    }
+
+    @ApiOperation(value = "칼로리 정보 불러오기 (목표 칼로리 대비 소모 칼로리 현황) 📝", notes = "특정 하루에 대한 나의 소모칼로리, 목표칼로리값을 불러옵니다.")
+    @ApiImplicitParam(name = "date", value = "오늘 날짜", required = true, dataType = "string")
+    @GetMapping("/calorie-state")
+    public ResponseEntity<GetCalorieStateRes> getCalorieState (
+            @DateTimeFormat(pattern = "yyyy-MM-dd")
+            @RequestParam LocalDate date) {
+        return ResponseDto.ok(new GetCalorieStateRes());
+    }
+}

--- a/src/main/java/com/dnd/Exercise/domain/exercise/dto/request/AppleWorkoutDto.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/dto/request/AppleWorkoutDto.java
@@ -1,0 +1,25 @@
+package com.dnd.Exercise.domain.exercise.dto.request;
+
+import com.dnd.Exercise.domain.sports.entity.Sports;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class AppleWorkoutDto {
+    private String appleUid;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime startDateTime;
+
+    @DateTimeFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime endDateTime;
+
+    private Sports sports;
+
+    private int burnedCalorie;
+}

--- a/src/main/java/com/dnd/Exercise/domain/exercise/dto/request/PostExerciseByAppleReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/dto/request/PostExerciseByAppleReq.java
@@ -1,0 +1,12 @@
+package com.dnd.Exercise.domain.exercise.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class PostExerciseByAppleReq {
+    List<AppleWorkoutDto> appleWorkouts;
+}

--- a/src/main/java/com/dnd/Exercise/domain/exercise/dto/request/PostExerciseByCommonReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/dto/request/PostExerciseByCommonReq.java
@@ -1,0 +1,24 @@
+package com.dnd.Exercise.domain.exercise.dto.request;
+
+import com.dnd.Exercise.domain.exercise.entity.RecordProvider;
+import com.dnd.Exercise.domain.sports.entity.Sports;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class PostExerciseByCommonReq {
+    private Sports sports;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate exerciseDate;
+    private int durationMinute;
+    private int burnedCalorie;
+
+    private String memoImg;
+    private String memoContent;
+    private Boolean isMemoPublic;
+}

--- a/src/main/java/com/dnd/Exercise/domain/exercise/dto/request/UpdateExerciseReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/dto/request/UpdateExerciseReq.java
@@ -1,0 +1,23 @@
+package com.dnd.Exercise.domain.exercise.dto.request;
+
+import com.dnd.Exercise.domain.sports.entity.Sports;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class UpdateExerciseReq {
+    private long id;
+    private Sports sports;
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate exerciseDate;
+    private int durationMinute;
+    private int burnedCalorie;
+
+    private String memoImg;
+    private String memoContent;
+    private Boolean isMemoPublic;
+}

--- a/src/main/java/com/dnd/Exercise/domain/exercise/dto/response/ExerciseDetailDto.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/dto/response/ExerciseDetailDto.java
@@ -1,0 +1,43 @@
+package com.dnd.Exercise.domain.exercise.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.dnd.Exercise.domain.exercise.entity.Exercise;
+import com.dnd.Exercise.domain.exercise.entity.RecordProvider;
+import com.dnd.Exercise.domain.sports.entity.Sports;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+public class ExerciseDetailDto {
+
+    private Long id;
+
+    private Sports sports;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private LocalDate exerciseDate;
+    private int durationMinute;
+    private int burnedCalorie;
+
+    private String memoImg;
+    private String memoContent;
+    private Boolean isMemoPublic;
+
+    private RecordProvider recordProvider;
+    private String appleUid;
+
+    public ExerciseDetailDto(Exercise entity) {
+        this.id = entity.getId();
+        this.sports = entity.getSports();
+        this.exerciseDate = entity.getExerciseDate();
+        this.durationMinute = entity.getDurationMinute();
+        this.burnedCalorie = entity.getBurnedCalorie();
+        this.memoImg = entity.getMemoImg();
+        this.memoContent = entity.getMemoContent();
+        this.isMemoPublic = entity.isMemoPublic();
+        this.recordProvider = entity.getRecordProvider();
+        this.appleUid = entity.getAppleUid();
+    }
+}

--- a/src/main/java/com/dnd/Exercise/domain/exercise/dto/response/FindAllExerciseDetailsOfDayRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/dto/response/FindAllExerciseDetailsOfDayRes.java
@@ -1,0 +1,15 @@
+package com.dnd.Exercise.domain.exercise.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class FindAllExerciseDetailsOfDayRes {
+
+    private List<ExerciseDetailDto> exerciseList;
+
+    private int totalCount;
+}

--- a/src/main/java/com/dnd/Exercise/domain/exercise/dto/response/GetCalorieStateRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/dto/response/GetCalorieStateRes.java
@@ -1,0 +1,13 @@
+package com.dnd.Exercise.domain.exercise.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GetCalorieStateRes {
+
+    private int burnedCalorie;
+
+    private int goalCalorie;
+}

--- a/src/main/java/com/dnd/Exercise/domain/exercise/dto/response/GetMyExerciseSummaryRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/dto/response/GetMyExerciseSummaryRes.java
@@ -1,0 +1,17 @@
+package com.dnd.Exercise.domain.exercise.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GetMyExerciseSummaryRes {
+
+    private int totalBurnedCalorie;
+
+    private int totalExerciseCalorie;
+
+    private int totalExerciseTimeMinute;
+
+    private int totalRecordCount;
+}

--- a/src/main/java/com/dnd/Exercise/domain/exercise/dto/response/GetRatingExerciseSummaryRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/dto/response/GetRatingExerciseSummaryRes.java
@@ -1,0 +1,17 @@
+package com.dnd.Exercise.domain.exercise.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class GetRatingExerciseSummaryRes {
+
+    private int totalRecordCount;
+
+    private int goalAchievedCount;
+
+    private int totalBurnedCalorie;
+
+    private int totalExerciseTimeMinute;
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
운동 기록, 활동링 관련 controller, dto 작성

[ 운동 기록 ]
- 매치업 내부 운동기록 CRUD
- 애플 데이터 업데이트
- 칼로리 정보 불러오기
- 나의 하루 기록 요약
- (대결 지표로 사용되는) 나의 하루 기록 요약

[ 활동링 ]
- 애플에서 활동링 업데이트 시 반영

## 📋 변경 사항


## 🔍 Code Review
- 운동 즐겨찾기 관련은 아직 작성하지 않아서, 추후에 다시 PR 보내도록 하겠습니다.
- GetRatingExerciseSummaryRes (대결 지표로 사용되는 요약정보) 랑 GetMyExerciseSummaryRes (개인 운동기록 페이지에서 보여지는 요약정보) 를 하나의 GetSummaryRes 로 묶어서 관리할까 했는데.. 일단은 그냥 두었습니다..! 혹시 Exercise Summary 관련 Dto 가 더 많아지면 묶어도 될것같네요!
- validation 내용은 아직 넣지 않았습니다!

## 📸 ScreenShot

## 연결된 이슈 Close
 #17
