### PR TITLE
Feat: 운동기록 엔티티, 관련 DTO 에 '기록시간' 필드 추가

### DIFF
--- a/src/main/java/com/dnd/Exercise/domain/exercise/dto/response/ExerciseDetailDto.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/dto/response/ExerciseDetailDto.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 @Getter
 @NoArgsConstructor
@@ -18,6 +19,8 @@ public class ExerciseDetailDto {
     private Sports sports;
     @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate exerciseDate;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime recordingDateTime;
     private int durationMinute;
     private int burnedCalorie;
 
@@ -32,6 +35,7 @@ public class ExerciseDetailDto {
         this.id = entity.getId();
         this.sports = entity.getSports();
         this.exerciseDate = entity.getExerciseDate();
+        this.recordingDateTime = entity.getRecordingDateTime();
         this.durationMinute = entity.getDurationMinute();
         this.burnedCalorie = entity.getBurnedCalorie();
         this.memoImg = entity.getMemoImg();

--- a/src/main/java/com/dnd/Exercise/domain/exercise/entity/Exercise.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/entity/Exercise.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import javax.persistence.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import static javax.persistence.FetchType.LAZY;
 
@@ -27,6 +28,8 @@ public class Exercise extends BaseEntity {
     private Sports sports;
 
     private LocalDate exerciseDate;
+
+    private LocalDateTime recordingDateTime;
 
     private int durationMinute;
 


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- 운동을 기록한 시간을 알 수 있는 '기록시간' 필드를 추가합니다.

## 📋 변경 사항
- `Exercise` 엔티티
- `ExerciseDetailDto`

## 🔍 Code Review

## 📸 ScreenShot

## 연결된 이슈 Close
close #28 
