### PR TITLE
Feat: Swagger api 전달을 위해 '인증, 유저' 관련 컨트롤러 계층과 DTO 구현

### DIFF
--- a/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
@@ -1,0 +1,50 @@
+package com.dnd.Exercise.domain.auth.controller;
+
+import com.dnd.Exercise.domain.auth.dto.request.LoginReq;
+import com.dnd.Exercise.domain.auth.dto.request.RefreshReq;
+import com.dnd.Exercise.domain.auth.dto.request.SignUpReq;
+import com.dnd.Exercise.domain.auth.dto.response.AccessTokenRes;
+import com.dnd.Exercise.domain.auth.dto.response.TokenRes;
+import com.dnd.Exercise.global.common.ResponseDto;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Api(tags = "인증 🔐")
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    @ApiOperation(value = "회원가입 🔐", notes = "일반 회원가입 시 사용합니다.")
+    @PostMapping("/sign-up")
+    public ResponseEntity<String> signUp(@RequestBody SignUpReq signUpReq) {
+        return ResponseDto.ok("회원가입 완료");
+    }
+
+    @ApiOperation(value = "로그인 🔐", notes = "일반 로그인 시 사용합니다.")
+    @PostMapping("/login")
+    public ResponseEntity<TokenRes> login(@RequestBody LoginReq loginReq) {
+        return ResponseDto.ok(new TokenRes());
+    }
+
+    @ApiOperation(value = "회원가입 시 중복된 id 체크 🔐", notes = "사용 가능한 id 인지 체크합니다.")
+    @GetMapping("/id-available")
+    public ResponseEntity<Boolean> idAvailable(@RequestParam String uid) {
+        return ResponseDto.ok(true);
+    }
+
+    @ApiOperation(value = "access 토큰 만료 시 재발급 🔐", notes = "refresh 토큰으로 access 토큰을 갱신합니다.")
+    @PostMapping("/refresh")
+    public ResponseEntity<AccessTokenRes> refresh(@RequestBody RefreshReq refreshReq) {
+        return ResponseDto.ok(new AccessTokenRes());
+    }
+
+    @ApiOperation(value = "로그아웃 🔐", notes = "")
+    @GetMapping("/logout")
+    public ResponseEntity<String> logout() {
+        return ResponseDto.ok("로그아웃 성공");
+    }
+
+    // TODO: 아이디찾기, 비밀번호찾기(+수정) 추후 추가
+}

--- a/src/main/java/com/dnd/Exercise/domain/auth/controller/OAuthController.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/controller/OAuthController.java
@@ -1,0 +1,36 @@
+package com.dnd.Exercise.domain.auth.controller;
+
+import com.dnd.Exercise.domain.auth.dto.request.OAuthCodeReq;
+import com.dnd.Exercise.domain.auth.dto.response.TokenRes;
+import com.dnd.Exercise.global.common.ResponseDto;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api(tags = "소셜 인증 🔐")
+@RestController
+@RequestMapping("/oauth")
+public class OAuthController {
+
+    @ApiOperation(value = "애플 로그인 🔐", notes = "인가 코드를 전송합니다. <br> 이미 존재하는 유저이면 로그인 / 새로운 유저이면 회원가입 처리 후 로그인 시켜줍니다.")
+    @PostMapping("/apple-login")
+    public ResponseEntity<TokenRes> appleLogin(@RequestBody OAuthCodeReq oAuthCodeReq) {
+        return ResponseDto.ok(new TokenRes());
+    }
+
+    @ApiOperation(value = "카카오 로그인 🔐", notes = "인가 코드를 전송합니다. <br> 이미 존재하는 유저이면 로그인 / 새로운 유저이면 회원가입 처리 후 로그인 시켜줍니다.")
+    @PostMapping("/kakao-login")
+    public ResponseEntity<TokenRes> kakaoLogin(@RequestBody OAuthCodeReq oAuthCodeReq) {
+        return ResponseDto.ok(new TokenRes());
+    }
+
+    @ApiOperation(value = "구글 로그인 🔐", notes = "인가 코드를 전송합니다. <br> 이미 존재하는 유저이면 로그인 / 새로운 유저이면 회원가입 처리 후 로그인 시켜줍니다.")
+    @PostMapping("/google-login")
+    public ResponseEntity<TokenRes> googleLogin(@RequestBody OAuthCodeReq oAuthCodeReq) {
+        return ResponseDto.ok(new TokenRes());
+    }
+}

--- a/src/main/java/com/dnd/Exercise/domain/auth/dto/request/LoginReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/dto/request/LoginReq.java
@@ -1,0 +1,14 @@
+package com.dnd.Exercise.domain.auth.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class LoginReq {
+
+    private String uid;
+
+    private String password;
+
+}

--- a/src/main/java/com/dnd/Exercise/domain/auth/dto/request/OAuthCodeReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/dto/request/OAuthCodeReq.java
@@ -1,0 +1,10 @@
+package com.dnd.Exercise.domain.auth.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OAuthCodeReq {
+    private String code;
+}

--- a/src/main/java/com/dnd/Exercise/domain/auth/dto/request/RefreshReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/dto/request/RefreshReq.java
@@ -1,0 +1,10 @@
+package com.dnd.Exercise.domain.auth.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RefreshReq {
+    private String refreshToken;
+}

--- a/src/main/java/com/dnd/Exercise/domain/auth/dto/request/SignUpReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/dto/request/SignUpReq.java
@@ -1,0 +1,21 @@
+package com.dnd.Exercise.domain.auth.dto.request;
+
+import com.dnd.Exercise.domain.field.entity.SkillLevel;
+import com.dnd.Exercise.domain.user.entity.LoginType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SignUpReq {
+
+    private String uid;
+
+    private String password;
+
+    private String phoneNum;
+
+    private String name;
+
+    private SkillLevel skillLevel;
+}

--- a/src/main/java/com/dnd/Exercise/domain/auth/dto/response/AccessTokenRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/dto/response/AccessTokenRes.java
@@ -1,0 +1,10 @@
+package com.dnd.Exercise.domain.auth.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AccessTokenRes {
+    private String accessToken;
+}

--- a/src/main/java/com/dnd/Exercise/domain/auth/dto/response/TokenRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/dto/response/TokenRes.java
@@ -1,0 +1,13 @@
+package com.dnd.Exercise.domain.auth.dto.response;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class TokenRes {
+
+    private String accessToken;
+
+    private String refreshToken;
+}

--- a/src/main/java/com/dnd/Exercise/domain/user/controller/UserController.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/controller/UserController.java
@@ -1,14 +1,12 @@
 package com.dnd.Exercise.domain.user.controller;
 
+import com.dnd.Exercise.domain.user.dto.request.*;
+import com.dnd.Exercise.domain.user.dto.response.GetProfileDetail;
 import com.dnd.Exercise.global.common.ResponseDto;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Api(tags = "사용자 👤")
 @RestController
@@ -23,5 +21,41 @@ public class UserController {
         } catch (Exception e) {
             throw new RuntimeException();
         }
+    }
+
+    @ApiOperation(value = "내 정보 상세 조회 👤", notes = "'마이페이지' 사용")
+    @GetMapping("/my/profile-detail")
+    public ResponseEntity<GetProfileDetail> getProfileDetail() {
+        return ResponseDto.ok(new GetProfileDetail());
+    }
+
+    @ApiOperation(value = "온보딩 시 내 정보 업데이트 👤", notes = "[ 신체정보(몸무게,키) / 목표칼로리 / 성별 / 애플 연동 여부 / (연동유저일 경우) 목표칼로리 ] 정보를 입력합니다. <br> '애플 초기 연동' or '연동 안한 유저의 온보딩' 에서 사용합니다.")
+    @PatchMapping("/my/onboard-profile")
+    public ResponseEntity<String> updateOnboardProfile(@RequestBody UpdateOnboardProfileReq updateOnboardProfileReq) {
+        return ResponseDto.ok("온보딩 정보 업데이트 완료");
+    }
+
+    @ApiOperation(value = "온보딩 시 운동레벨 등록 👤", notes = "[ 일반로그인의 경우 ] 회원가입을 진행하며 운동레벨을 함께 등록하므로, 이 api 를 사용하지 않습니다. <br> [ 소셜로그인의 경우 ] 소셜 회원가입 마친 뒤, 이 api 를 사용해 운동레벨을 추가로 등록합니다.")
+    @PostMapping("/my/skill-level")
+    public ResponseEntity<String> postSkillLevel(@RequestBody PostSkillLevelReq postSkillLevelReq) {
+        return ResponseDto.ok("운동레벨 등록 완료");
+    }
+
+    @ApiOperation(value = "내 프로필 수정 👤", notes = "'마이페이지' 사용 <br> 목표 칼로리는 수정할 수 없다.")
+    @PatchMapping("/my/profile")
+    public ResponseEntity<String> updateProfile(@RequestBody UpdateMyProfileReq updateMyProfileReq) {
+        return ResponseDto.ok("프로필 수정 완료");
+    }
+
+    @ApiOperation(value = "애플 연동 여부 수정 👤", notes = "애플 연동 설정/해제 시 해당 정보 업데이트")
+    @PatchMapping("/my/apple-linked")
+    public ResponseEntity<String> updateAppleLinked(@RequestBody UpdateAppleLinkedReq updateAppleLinkedReq) {
+        return ResponseDto.ok("연동 정보 수정 완료");
+    }
+
+    @ApiOperation(value = "알림 수신 여부 수정 👤", notes = "푸시알림 수신 여부를 설정합니다.")
+    @PatchMapping("/my/notification-agreement")
+    public ResponseEntity<String> updateNotificationAgreement(@RequestBody UpdateNotificationAgreementReq updateNotificationAgreementReq) {
+        return ResponseDto.ok("알림 수신여부 수정 완료");
     }
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/request/PostSkillLevelReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/request/PostSkillLevelReq.java
@@ -1,0 +1,11 @@
+package com.dnd.Exercise.domain.user.dto.request;
+
+import com.dnd.Exercise.domain.field.entity.SkillLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PostSkillLevelReq {
+    private SkillLevel skillLevel;
+}

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateAppleLinkedReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateAppleLinkedReq.java
@@ -1,0 +1,11 @@
+package com.dnd.Exercise.domain.user.dto.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateAppleLinkedReq {
+    private Boolean isAppleLinked;
+}

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateMyProfileReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateMyProfileReq.java
@@ -1,0 +1,21 @@
+package com.dnd.Exercise.domain.user.dto.request;
+
+import com.dnd.Exercise.domain.field.entity.SkillLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateMyProfileReq {
+    private String name;
+
+    private String profileImg;
+
+    private int age;
+
+    private int height;
+
+    private int weight;
+
+    private SkillLevel skillLevel;
+}

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateNotificationAgreementReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateNotificationAgreementReq.java
@@ -1,0 +1,10 @@
+package com.dnd.Exercise.domain.user.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateNotificationAgreementReq {
+    private Boolean isNotificationAgreed;
+}

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateOnboardProfileReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateOnboardProfileReq.java
@@ -1,0 +1,19 @@
+package com.dnd.Exercise.domain.user.dto.request;
+
+import com.dnd.Exercise.domain.user.entity.Gender;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateOnboardProfileReq {
+    private int weight;
+
+    private int height;
+
+    private Gender gender;
+
+    private Boolean isAppleLinked;
+
+    private int calorieGoal;
+}

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/response/GetProfileDetail.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/response/GetProfileDetail.java
@@ -1,0 +1,38 @@
+package com.dnd.Exercise.domain.user.dto.response;
+
+import com.dnd.Exercise.domain.field.entity.SkillLevel;
+import com.dnd.Exercise.domain.user.entity.Gender;
+import com.dnd.Exercise.domain.user.entity.LoginType;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+@Getter
+@NoArgsConstructor
+public class GetProfileDetail {
+    private String uid;
+
+    @Enumerated(EnumType.STRING)
+    private LoginType loginType;
+
+    private String name;
+    private String profileImg;
+
+    private String age;
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    private int height;
+    private int weight;
+
+    @Enumerated(EnumType.STRING)
+    private SkillLevel skillLevel;
+    private int calorieGoal;
+
+    private int teamworkRate;
+
+    private Boolean isNotificationAgreed;
+    private Boolean isAppleLinked;
+}

--- a/src/main/java/com/dnd/Exercise/domain/verification/controller/VerificationController.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/controller/VerificationController.java
@@ -1,0 +1,30 @@
+package com.dnd.Exercise.domain.verification.controller;
+
+import com.dnd.Exercise.domain.verification.dto.request.SendCodeReq;
+import com.dnd.Exercise.domain.verification.dto.request.VerifyReq;
+import com.dnd.Exercise.global.common.ResponseDto;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Api(tags = "전화번호 인증 📞")
+@RestController
+@RequestMapping("/verification")
+public class VerificationController {
+
+    @ApiOperation(value = "인증번호 전송 요청 📞", notes = "해당 전화번호로 인증번호를 발송합니다.")
+    @PostMapping("/send-code")
+    public ResponseEntity<String> sendCode(@RequestBody SendCodeReq sendCodeReq) {
+        return ResponseDto.ok("인증번호 발송 완료");
+    }
+
+    @ApiOperation(value = "인증번호 인증 📞", notes = "발송받은 인증번호로 인증을 수행합니다. 인증 성공 여부를 반환합니다.")
+    @PostMapping("/verify")
+    public ResponseEntity<Boolean> verify(@RequestBody VerifyReq verifyReq) {
+        return ResponseDto.ok(false);
+    }
+}

--- a/src/main/java/com/dnd/Exercise/domain/verification/dto/request/SendCodeReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/dto/request/SendCodeReq.java
@@ -1,0 +1,10 @@
+package com.dnd.Exercise.domain.verification.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SendCodeReq {
+    private String phoneNum;
+}

--- a/src/main/java/com/dnd/Exercise/domain/verification/dto/request/VerifyReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/dto/request/VerifyReq.java
@@ -1,0 +1,11 @@
+package com.dnd.Exercise.domain.verification.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class VerifyReq {
+
+    private String code;
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
인증, 유저 관련 controller, dto 작성

[ 유저 ]
- 내 정보 등록 / 수정 / 조회

[ 인증 ]
- 기본 회원가입 / 로그인 / 로그아웃 / 토큰재발급
- 소셜 로그인
- 전화번호 인증

## 📋 변경 사항
- `UserController`
- `AuthController`
- `OAuthController`
- `VerificationController`

## 🔍 Code Review

## 📸 ScreenShot

## 연결된 이슈 Close
close #18
