### PR TITLE
Feat: Field - 운동 요약, 랭킹, 기록 스레드 API 구현

### DIFF
--- a/src/main/java/com/dnd/Exercise/domain/activityRing/repository/ActivityRingRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/activityRing/repository/ActivityRingRepository.java
@@ -1,0 +1,12 @@
+package com.dnd.Exercise.domain.activityRing.repository;
+
+import com.dnd.Exercise.domain.activityRing.entity.ActivityRing;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ActivityRingRepository extends JpaRepository<ActivityRing, Long> {
+
+    List<ActivityRing> findAllByDateAndUserIdIn(LocalDate date, Collection<Long> id);
+}

--- a/src/main/java/com/dnd/Exercise/domain/activityRing/repository/ActivityRingRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/activityRing/repository/ActivityRingRepository.java
@@ -6,7 +6,8 @@ import java.util.Collection;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ActivityRingRepository extends JpaRepository<ActivityRing, Long> {
+public interface ActivityRingRepository
+        extends JpaRepository<ActivityRing, Long>, ActivityRingRepositoryCustom {
 
     List<ActivityRing> findAllByDateAndUserIdIn(LocalDate date, Collection<Long> id);
 }

--- a/src/main/java/com/dnd/Exercise/domain/activityRing/repository/ActivityRingRepositoryCustom.java
+++ b/src/main/java/com/dnd/Exercise/domain/activityRing/repository/ActivityRingRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.dnd.Exercise.domain.activityRing.repository;
+
+import com.dnd.Exercise.domain.field.dto.response.RankingDto;
+import com.dnd.Exercise.domain.field.entity.RankCriterion;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ActivityRingRepositoryCustom {
+    List<RankingDto> findTopByDynamicCriteria(RankCriterion rankCriterion, LocalDate date, List<Long> userIds);
+}

--- a/src/main/java/com/dnd/Exercise/domain/activityRing/repository/ActivityRingRepositoryImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/activityRing/repository/ActivityRingRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com.dnd.Exercise.domain.activityRing.repository;
+
+import static com.dnd.Exercise.domain.activityRing.entity.QActivityRing.activityRing;
+import static com.dnd.Exercise.domain.exercise.entity.QExercise.exercise;
+import static com.dnd.Exercise.domain.user.entity.QUser.user;
+
+import com.dnd.Exercise.domain.activityRing.entity.QActivityRing;
+import com.dnd.Exercise.domain.field.dto.response.RankingDto;
+import com.dnd.Exercise.domain.field.entity.RankCriterion;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ActivityRingRepositoryImpl implements ActivityRingRepositoryCustom{
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<RankingDto> findTopByDynamicCriteria(RankCriterion rankCriterion, LocalDate date,
+            List<Long> userIds) {
+
+        NumberExpression<?> aggregateExpression = getAggregateExpression(rankCriterion);
+
+        return queryFactory
+                .select(Projections.constructor(RankingDto.class, user.id, user.profileImg, aggregateExpression))
+                .from(activityRing)
+                .join(activityRing.user,
+                        user)
+                .where(activityRing.date.eq(date)
+                        .and(activityRing.user.id.in(userIds)))
+                .groupBy(user)
+                .orderBy(aggregateExpression.desc())
+                .limit(3)
+                .fetch();
+    }
+
+    private NumberExpression<?> getAggregateExpression(RankCriterion criterion) {
+        switch (criterion) {
+            case BURNED_CALORIE:
+                return activityRing.burnedCalorie.sum();
+            case GOAL_ACHIEVED:
+                return activityRing.isGoalAchieved.castToNum(Integer.class).sum();
+            default:
+                throw new IllegalArgumentException("Invalid criterion: " + criterion);
+        }
+    }
+}

--- a/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepository.java
@@ -1,0 +1,10 @@
+package com.dnd.Exercise.domain.exercise.repository;
+
+import com.dnd.Exercise.domain.exercise.entity.Exercise;
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
+    List<Exercise> findAllByExerciseDateAndUserIdIn(LocalDate exerciseDate, List<Long> userIds);
+}

--- a/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepository.java
@@ -3,8 +3,13 @@ package com.dnd.Exercise.domain.exercise.repository;
 import com.dnd.Exercise.domain.exercise.entity.Exercise;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ExerciseRepository extends JpaRepository<Exercise, Long>, ExerciseRepositoryCustom {
     List<Exercise> findAllByExerciseDateAndUserIdIn(LocalDate exerciseDate, List<Long> userIds);
+
+    @EntityGraph(attributePaths = "user")
+    Optional<Exercise> findWithUserById(Long exerciseId);
 }

--- a/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepository.java
@@ -5,6 +5,6 @@ import java.time.LocalDate;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
+public interface ExerciseRepository extends JpaRepository<Exercise, Long>, ExerciseRepositoryCustom {
     List<Exercise> findAllByExerciseDateAndUserIdIn(LocalDate exerciseDate, List<Long> userIds);
 }

--- a/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepositoryCustom.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepositoryCustom.java
@@ -1,12 +1,15 @@
 package com.dnd.Exercise.domain.exercise.repository;
 
+import com.dnd.Exercise.domain.field.dto.response.FindFieldRecordDto;
 import com.dnd.Exercise.domain.field.dto.response.RankingDto;
 import com.dnd.Exercise.domain.field.entity.RankCriterion;
-import com.querydsl.core.Tuple;
 import java.time.LocalDate;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 
 public interface ExerciseRepositoryCustom {
 
     List<RankingDto> findTopByDynamicCriteria(RankCriterion rankCriterion, LocalDate date, List<Long> userIds);
+
+    List<FindFieldRecordDto> findAllWithUser(LocalDate date, List<Long> userIds, Pageable pageable, Long leaderId);
 }

--- a/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepositoryCustom.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepositoryCustom.java
@@ -1,0 +1,12 @@
+package com.dnd.Exercise.domain.exercise.repository;
+
+import com.dnd.Exercise.domain.field.dto.response.RankingDto;
+import com.dnd.Exercise.domain.field.entity.RankCriterion;
+import com.querydsl.core.Tuple;
+import java.time.LocalDate;
+import java.util.List;
+
+public interface ExerciseRepositoryCustom {
+
+    List<RankingDto> findTopByDynamicCriteria(RankCriterion rankCriterion, LocalDate date, List<Long> userIds);
+}

--- a/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepositoryImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.dnd.Exercise.domain.exercise.repository;
+
+import static com.dnd.Exercise.domain.exercise.entity.QExercise.exercise;
+import static com.dnd.Exercise.domain.user.entity.QUser.user;
+
+import com.dnd.Exercise.domain.field.dto.response.RankingDto;
+import com.dnd.Exercise.domain.field.entity.RankCriterion;
+import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class ExerciseRepositoryImpl implements ExerciseRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<RankingDto> findTopByDynamicCriteria(RankCriterion rankCriterion, LocalDate date,
+            List<Long> userIds) {
+
+        NumberExpression<?> aggregateExpression = getAggregateExpression(rankCriterion);
+
+        return queryFactory
+                .select(Projections.constructor(RankingDto.class, user.id, user.profileImg, aggregateExpression))
+                .from(exercise)
+                .join(exercise.user,
+                        user)
+                .where(exercise.exerciseDate.eq(date)
+                        .and(exercise.user.id.in(userIds)))
+                .groupBy(user)
+                .orderBy(aggregateExpression.desc())
+                .limit(3)
+                .fetch();
+    }
+
+    private NumberExpression<?> getAggregateExpression(RankCriterion criterion) {
+        switch (criterion) {
+            case EXERCISE_TIME:
+                return exercise.durationMinute.sum();
+            case RECORD_COUNT:
+                return exercise.count().castToNum(Integer.class);
+            default:
+                throw new IllegalArgumentException("Invalid criterion: " + criterion);
+        }
+    }
+}
+
+
+
+
+
+

--- a/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepositoryImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepositoryImpl.java
@@ -3,14 +3,18 @@ package com.dnd.Exercise.domain.exercise.repository;
 import static com.dnd.Exercise.domain.exercise.entity.QExercise.exercise;
 import static com.dnd.Exercise.domain.user.entity.QUser.user;
 
+import com.dnd.Exercise.domain.field.dto.response.FindFieldRecordDto;
+import com.dnd.Exercise.domain.field.dto.response.QFindFieldRecordDto;
 import com.dnd.Exercise.domain.field.dto.response.RankingDto;
 import com.dnd.Exercise.domain.field.entity.RankCriterion;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.NumberExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -36,6 +40,30 @@ public class ExerciseRepositoryImpl implements ExerciseRepositoryCustom {
                 .orderBy(aggregateExpression.desc())
                 .limit(3)
                 .fetch();
+    }
+
+    @Override
+    public List<FindFieldRecordDto> findAllWithUser(LocalDate date, List<Long> userIds, Pageable pageable, Long leaderId) {
+
+        BooleanExpression isLeader = getIsLeader(leaderId);
+
+        return queryFactory
+                .select(new QFindFieldRecordDto(exercise.id, user.id, user.profileImg, user.name,
+                        isLeader, exercise.sports, exercise.recordingDateTime, exercise.durationMinute,
+                        exercise.burnedCalorie, exercise.memoImg, exercise.memoContent,
+                        exercise.isMemoPublic))
+                .from(exercise)
+                .join(exercise.user, user)
+                .where(exercise.exerciseDate.eq(date)
+                .and(exercise.user.id.in(userIds)))
+                .orderBy(exercise.recordingDateTime.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    private BooleanExpression getIsLeader(Long leaderId){
+        return user.id.eq(leaderId);
     }
 
     private NumberExpression<?> getAggregateExpression(RankCriterion criterion) {

--- a/src/main/java/com/dnd/Exercise/domain/field/controller/FieldController.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/controller/FieldController.java
@@ -195,10 +195,11 @@ public class FieldController {
     @ApiOperation(value = "[필드 - 기록] 페이지 스레드 단일 운동 조회", notes = "운동 내역 클릭시")
     @GetMapping("{fieldId}/record/{exerciseId}")
     public ResponseEntity<FindFieldRecordDto> findFieldRecord(
+            @AuthenticationPrincipal User user,
             @Parameter(description = "필드 Id값") @PathVariable("fieldId") Long fieldId,
             @Parameter(description = "운동 Id값") @PathVariable("exerciseId") Long exerciseId){
-        FindFieldRecordDto findFieldRecordDto = new FindFieldRecordDto();
-        return ResponseDto.ok(findFieldRecordDto);
+        FindFieldRecordDto result = fieldService.findFieldRecord(user, fieldId, exerciseId);
+        return ResponseDto.ok(result);
     }
 
 

--- a/src/main/java/com/dnd/Exercise/domain/field/controller/FieldController.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/controller/FieldController.java
@@ -3,7 +3,7 @@ package com.dnd.Exercise.domain.field.controller;
 import com.dnd.Exercise.domain.field.dto.request.CreateFieldReq;
 import com.dnd.Exercise.domain.field.dto.request.FindAllFieldRecordsReq;
 import com.dnd.Exercise.domain.field.dto.request.FindAllFieldsCond;
-import com.dnd.Exercise.domain.field.dto.request.GetFieldExerciseSummaryReq;
+import com.dnd.Exercise.domain.field.dto.request.FieldSideDateReq;
 import com.dnd.Exercise.domain.field.dto.request.UpdateFieldInfoReq;
 import com.dnd.Exercise.domain.field.dto.request.UpdateFieldProfileReq;
 import com.dnd.Exercise.domain.field.dto.response.AutoMatchingRes;
@@ -13,7 +13,6 @@ import com.dnd.Exercise.domain.field.dto.response.FindFieldRecordDto;
 import com.dnd.Exercise.domain.field.dto.response.FindFieldRes;
 import com.dnd.Exercise.domain.field.dto.response.GetFieldExerciseSummaryRes;
 import com.dnd.Exercise.domain.field.dto.response.GetRankingRes;
-import com.dnd.Exercise.domain.field.entity.FieldSide;
 import com.dnd.Exercise.domain.field.entity.FieldType;
 import com.dnd.Exercise.domain.field.service.FieldService;
 import com.dnd.Exercise.domain.user.entity.User;
@@ -154,7 +153,7 @@ public class FieldController {
     public ResponseEntity<GetFieldExerciseSummaryRes> getFieldExerciseSummary (
             @AuthenticationPrincipal User user,
             @Parameter(description = "필드 Id값") @PathVariable("id") Long fieldId,
-            @RequestBody GetFieldExerciseSummaryReq summaryReq) {
+            @RequestBody FieldSideDateReq summaryReq) {
         GetFieldExerciseSummaryRes result = fieldService.getFieldExerciseSummary(user, fieldId, summaryReq);
         return ResponseDto.ok(result);
     }
@@ -164,11 +163,11 @@ public class FieldController {
     @ApiImplicitParam(name = "date", value = "선택 날짜", required = true, dataType = "string")
     @GetMapping("/{id}/team/ranking")
     public ResponseEntity<GetRankingRes> getTeamRanking(
+            @AuthenticationPrincipal User user,
             @Parameter(description = "필드 Id값") @PathVariable("id") Long fieldId,
-            @DateTimeFormat(pattern = "yyyy-MM-dd") @RequestParam LocalDate date,
-            @RequestParam FieldSide fieldSide){
-        GetRankingRes getTeamRankingRes = new GetRankingRes();
-        return ResponseDto.ok(getTeamRankingRes);
+            @RequestBody FieldSideDateReq teamRankingReq){
+        GetRankingRes result = fieldService.getTeamRanking(user, fieldId, teamRankingReq);
+        return ResponseDto.ok(result);
     }
 
     @ApiOperation(value = "1:1 배틀 랭킹 조회 🔥", notes = "1:1 배틀에서만 사용")

--- a/src/main/java/com/dnd/Exercise/domain/field/controller/FieldController.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/controller/FieldController.java
@@ -174,10 +174,11 @@ public class FieldController {
     @ApiImplicitParam(name = "date", value = "선택 날짜", required = true, dataType = "string")
     @GetMapping("/{id}/duel/ranking")
     public ResponseEntity<GetRankingRes> getDuelRanking(
+            @AuthenticationPrincipal User user,
             @Parameter(description = "필드 Id값") @PathVariable("id") Long fieldId,
             @DateTimeFormat(pattern = "yyyy-MM-dd") @RequestParam LocalDate date){
-        GetRankingRes getDuelRankingRes = new GetRankingRes();
-        return ResponseDto.ok(getDuelRankingRes);
+        GetRankingRes result = fieldService.getDuelRanking(user, fieldId, date);
+        return ResponseDto.ok(result);
     }
 
     @ApiOperation(value = "[필드 - 기록] 페이지 스레드 리스트 조회")

--- a/src/main/java/com/dnd/Exercise/domain/field/controller/FieldController.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/controller/FieldController.java
@@ -3,6 +3,7 @@ package com.dnd.Exercise.domain.field.controller;
 import com.dnd.Exercise.domain.field.dto.request.CreateFieldReq;
 import com.dnd.Exercise.domain.field.dto.request.FindAllFieldRecordsReq;
 import com.dnd.Exercise.domain.field.dto.request.FindAllFieldsCond;
+import com.dnd.Exercise.domain.field.dto.request.GetFieldExerciseSummaryReq;
 import com.dnd.Exercise.domain.field.dto.request.UpdateFieldInfoReq;
 import com.dnd.Exercise.domain.field.dto.request.UpdateFieldProfileReq;
 import com.dnd.Exercise.domain.field.dto.response.AutoMatchingRes;
@@ -143,18 +144,19 @@ public class FieldController {
         return ResponseDto.ok("배틀 중단 완료");
     }
 
-    // DB에서 SUM 연산해서 가져오기, 양방향 매핑 고려
+    //  양방향 매핑 고려
     @ApiOperation(value = " (대결 지표로 사용되는) 나의 필드 or 상대편 필드 하루 요약 조회 🔥",
             notes = "특정 하루에 대한 [기록횟수, 오늘까지의 활동링 달성 횟수, 운동시간, 소모 칼로리] 정보 조회 <br>"
-                    + "우리팀 요약: HOME, 상대팀 요약: AWAY <br>'홈화면', '하루 요약'에서 사용")
+                    + "우리팀 요약: HOME, 상대팀 요약: AWAY <br>'하루 요약'에서 사용 <br>"
+                    + "배틀 상대가 있는 필드로 HOME 조회 시 나의 승리 여부와 상대 필드 이름도 조회됩니다.")
     @ApiImplicitParam(name = "date", value = "선택 날짜", required = true, dataType = "string")
     @GetMapping("/{id}/rating-summary")
     public ResponseEntity<GetFieldExerciseSummaryRes> getFieldExerciseSummary (
+            @AuthenticationPrincipal User user,
             @Parameter(description = "필드 Id값") @PathVariable("id") Long fieldId,
-            @DateTimeFormat(pattern = "yyyy-MM-dd") @RequestParam LocalDate date,
-            @RequestParam FieldSide fieldSide) {
-        GetFieldExerciseSummaryRes getFieldExerciseSummaryRes = new GetFieldExerciseSummaryRes();
-        return ResponseDto.ok(getFieldExerciseSummaryRes);
+            @RequestBody GetFieldExerciseSummaryReq summaryReq) {
+        GetFieldExerciseSummaryRes result = fieldService.getFieldExerciseSummary(user, fieldId, summaryReq);
+        return ResponseDto.ok(result);
     }
 
     // DB에서 RANK 사용해서 상위 3개만 추출

--- a/src/main/java/com/dnd/Exercise/domain/field/controller/FieldController.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/controller/FieldController.java
@@ -8,7 +8,6 @@ import com.dnd.Exercise.domain.field.dto.request.UpdateFieldInfoReq;
 import com.dnd.Exercise.domain.field.dto.request.UpdateFieldProfileReq;
 import com.dnd.Exercise.domain.field.dto.response.AutoMatchingRes;
 import com.dnd.Exercise.domain.field.dto.response.FindAllFieldsRes;
-import com.dnd.Exercise.domain.field.dto.response.FindAllFieldRecordsRes;
 import com.dnd.Exercise.domain.field.dto.response.FindFieldRecordDto;
 import com.dnd.Exercise.domain.field.dto.response.FindFieldRes;
 import com.dnd.Exercise.domain.field.dto.response.GetFieldExerciseSummaryRes;
@@ -22,6 +21,7 @@ import io.swagger.annotations.ApiImplicitParam;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.v3.oas.annotations.Parameter;
 import java.time.LocalDate;
+import java.util.List;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -181,13 +181,15 @@ public class FieldController {
         return ResponseDto.ok(result);
     }
 
-    @ApiOperation(value = "[필드 - 기록] 페이지 스레드 리스트 조회")
+    @ApiOperation(value = "[필드 - 기록] 페이지 스레드 리스트 조회",
+            notes = " page 기본값: 0, size 기본값: 3")
     @GetMapping("{id}/record")
-    public ResponseEntity<FindAllFieldRecordsRes> findAllFieldRecords(
+    public ResponseEntity<List<FindFieldRecordDto>> findAllFieldRecords(
+            @AuthenticationPrincipal User user,
             @Parameter(description = "필드 Id값") @PathVariable("id") Long fieldId,
-            @RequestBody FindAllFieldRecordsReq findAllFieldRecordsReq){
-        FindAllFieldRecordsRes findAllFieldRecordsRes = new FindAllFieldRecordsRes();
-        return ResponseDto.ok(findAllFieldRecordsRes);
+            @RequestBody @Valid FindAllFieldRecordsReq recordsReq){
+        List<FindFieldRecordDto> result = fieldService.findAllFieldRecords(user, fieldId, recordsReq);
+        return ResponseDto.ok(result);
     }
 
     @ApiOperation(value = "[필드 - 기록] 페이지 스레드 단일 운동 조회", notes = "운동 내역 클릭시")
@@ -202,4 +204,5 @@ public class FieldController {
 
     //매치 종료 스케줄러
     //매치 종료 Get
+    //매치 상태값 Get
 }

--- a/src/main/java/com/dnd/Exercise/domain/field/dto/FieldMapper.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/dto/FieldMapper.java
@@ -1,13 +1,17 @@
 package com.dnd.Exercise.domain.field.dto;
 
+import com.dnd.Exercise.domain.exercise.entity.Exercise;
 import com.dnd.Exercise.domain.field.dto.request.UpdateFieldInfoReq;
 import com.dnd.Exercise.domain.field.dto.request.UpdateFieldProfileReq;
 import com.dnd.Exercise.domain.field.dto.response.AutoMatchingRes;
 import com.dnd.Exercise.domain.field.dto.response.FieldDto;
 import com.dnd.Exercise.domain.field.dto.response.FindAllFieldsDto;
+import com.dnd.Exercise.domain.field.dto.response.FindFieldRecordDto;
 import com.dnd.Exercise.domain.field.entity.Field;
+import com.dnd.Exercise.domain.user.entity.User;
 import com.dnd.Exercise.global.util.GenericMapper;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 
 @Mapper(componentModel = "spring")
 public interface FieldMapper extends GenericMapper<UpdateFieldProfileReq, Field>,
@@ -18,4 +22,7 @@ public interface FieldMapper extends GenericMapper<UpdateFieldProfileReq, Field>
     FieldDto toFieldDto(Field field);
 
     AutoMatchingRes toAutoMatchingRes(Field field);
+
+    @Mapping(source = "exercise.recordingDateTime", target = "exerciseDateTime")
+    FindFieldRecordDto toFindFieldRecordDto(Exercise exercise);
 }

--- a/src/main/java/com/dnd/Exercise/domain/field/dto/request/CreateFieldReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/dto/request/CreateFieldReq.java
@@ -6,6 +6,7 @@ import com.dnd.Exercise.domain.field.entity.Goal;
 import com.dnd.Exercise.domain.field.entity.FieldType;
 import com.dnd.Exercise.domain.field.entity.SkillLevel;
 import com.dnd.Exercise.domain.field.entity.Strength;
+import io.swagger.annotations.ApiModelProperty;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
@@ -16,31 +17,41 @@ import org.hibernate.validator.constraints.Range;
 public class CreateFieldReq {
 
     @NotBlank
+    @ApiModelProperty(notes = "이름", required = true)
     private String name;
-
+    @ApiModelProperty(notes = "프로필 이미지")
     private String profileImg;
 
     @NotNull
+    @ApiModelProperty(notes = "운동강도", required = true, example = "LOW | MODERATE | HIGH")
     private Strength strength;
 
     @NotNull
+    @ApiModelProperty(notes = "카테고리", required = true, example = "GAIN | LOSS | MAINTENANCE | PROFILE")
     private Goal goal;
 
+    @ApiModelProperty(notes = "팀 규칙")
     private String rule;
 
     @Range(min = 1, max = 10)
     @NotNull
+    @ApiModelProperty(notes = "팀 인원수 - 최소 1, 최대 10", required = true)
     private int maxSize;
 
     @NotNull
+    @ApiModelProperty(notes = "진행기간", required = true, example = "ONE_WEEK | TWO_WEEKS | THREE_WEEKS")
     private Period period;
 
+    @ApiModelProperty(notes = "팀 소개", required = true)
     private String description;
 
     @NotNull
+    @ApiModelProperty(notes = "매칭", required = true, example = "DUEL | TEAM_BATTLE | TEAM")
     private FieldType fieldType;
 
     @NotNull
+    @ApiModelProperty(notes = "운동레벨", required = true,
+            example = "BEGINNER | INTERMEDIATE | ADVANCED_INTERMEDIATE | EXPERT")
     private SkillLevel skillLevel;
 
     public Field toEntity(Long leaderId){

--- a/src/main/java/com/dnd/Exercise/domain/field/dto/request/FieldSideDateReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/dto/request/FieldSideDateReq.java
@@ -1,6 +1,7 @@
 package com.dnd.Exercise.domain.field.dto.request;
 
 import com.dnd.Exercise.domain.field.entity.FieldSide;
+import io.swagger.annotations.ApiModelProperty;
 import java.time.LocalDate;
 import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -8,7 +9,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 @Data
 public class FieldSideDateReq {
     @DateTimeFormat(pattern = "yyyy-MM-dd")
+    @ApiModelProperty(notes = "선택날짜", required = true)
     private LocalDate date;
-
+    @ApiModelProperty(required = true, example = "HOME | AWAY")
     private FieldSide fieldSide;
 }

--- a/src/main/java/com/dnd/Exercise/domain/field/dto/request/FieldSideDateReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/dto/request/FieldSideDateReq.java
@@ -6,7 +6,7 @@ import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
 
 @Data
-public class GetFieldExerciseSummaryReq {
+public class FieldSideDateReq {
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 

--- a/src/main/java/com/dnd/Exercise/domain/field/dto/request/FindAllFieldRecordsReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/dto/request/FindAllFieldRecordsReq.java
@@ -2,17 +2,21 @@ package com.dnd.Exercise.domain.field.dto.request;
 
 import com.dnd.Exercise.domain.field.entity.FieldType;
 import java.time.LocalDate;
+import javax.validation.constraints.NotNull;
 import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
 
 @Data
 public class FindAllFieldRecordsReq {
-    private int page;
 
-    private int size;
+    private int page = 0;
 
+    private int size = 3;
+
+    @NotNull
     @DateTimeFormat(pattern = "yyyy-MM-dd")
     private LocalDate date;
 
+    @NotNull
     private FieldType fieldType;
 }

--- a/src/main/java/com/dnd/Exercise/domain/field/dto/request/FindAllFieldsCond.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/dto/request/FindAllFieldsCond.java
@@ -5,21 +5,22 @@ import com.dnd.Exercise.domain.field.entity.Goal;
 import com.dnd.Exercise.domain.field.entity.FieldType;
 import com.dnd.Exercise.domain.field.entity.SkillLevel;
 import com.dnd.Exercise.domain.field.entity.Strength;
+import io.swagger.annotations.ApiModelProperty;
 import java.util.List;
 import lombok.Getter;
 
 @Getter
 public class FindAllFieldsCond {
-
+    @ApiModelProperty(notes = "매칭유형", required = true, example = "DUEL | TEAM_BATTLE | TEAM")
     private FieldType fieldType;
-
+    @ApiModelProperty(notes = "팀 인원수 - 최소 1, 최대 10")
     private Integer memberCount;
-
+    @ApiModelProperty(notes = "운동레벨", example = "[BEGINNER, INTERMEDIATE, ADVANCED_INTERMEDIATE, EXPERT]")
     private List<SkillLevel> skillLevel;
-
+    @ApiModelProperty(notes = "운동강도", example = "[LOW, MODERATE, HIGH]")
     private List<Strength> strength;
-
+    @ApiModelProperty(notes = "진행기간", example = "[ONE_WEEK, TWO_WEEKS, THREE_WEEKS]")
     private List<Period> period;
-
+    @ApiModelProperty(notes = "카테고리", example = "[GAIN, LOSS, MAINTENANCE, PROFILE]")
     private List<Goal> goal;
 }

--- a/src/main/java/com/dnd/Exercise/domain/field/dto/request/GetFieldExerciseSummaryReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/dto/request/GetFieldExerciseSummaryReq.java
@@ -1,0 +1,14 @@
+package com.dnd.Exercise.domain.field.dto.request;
+
+import com.dnd.Exercise.domain.field.entity.FieldSide;
+import java.time.LocalDate;
+import lombok.Data;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Data
+public class GetFieldExerciseSummaryReq {
+    @DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate date;
+
+    private FieldSide fieldSide;
+}

--- a/src/main/java/com/dnd/Exercise/domain/field/dto/response/FindFieldRecordDto.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/dto/response/FindFieldRecordDto.java
@@ -2,10 +2,13 @@ package com.dnd.Exercise.domain.field.dto.response;
 
 import com.dnd.Exercise.domain.sports.entity.Sports;
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 public class FindFieldRecordDto {
 
     private Long id;
@@ -32,4 +35,23 @@ public class FindFieldRecordDto {
     private String memoContent;
 
     private Boolean isMemoPublic;
+
+    @QueryProjection
+    public FindFieldRecordDto(Long id, Long userId, String profileImg, String name,
+            Boolean isLeader,
+            Sports sports, LocalDateTime exerciseDateTime, int durationMinute, int burnedCalorie,
+            String memoImg, String memoContent, Boolean isMemoPublic) {
+        this.id = id;
+        this.userId = userId;
+        this.profileImg = profileImg;
+        this.name = name;
+        this.isLeader = isLeader;
+        this.sports = sports;
+        this.exerciseDateTime = exerciseDateTime;
+        this.durationMinute = durationMinute;
+        this.burnedCalorie = burnedCalorie;
+        this.memoImg = memoImg;
+        this.memoContent = memoContent;
+        this.isMemoPublic = isMemoPublic;
+    }
 }

--- a/src/main/java/com/dnd/Exercise/domain/field/dto/response/GetFieldExerciseSummaryRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/dto/response/GetFieldExerciseSummaryRes.java
@@ -1,11 +1,15 @@
 package com.dnd.Exercise.domain.field.dto.response;
 
 import com.dnd.Exercise.domain.field.entity.WinStatus;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class GetFieldExerciseSummaryRes {
 
     private int totalRecordCount;

--- a/src/main/java/com/dnd/Exercise/domain/field/dto/response/GetFieldExerciseSummaryRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/dto/response/GetFieldExerciseSummaryRes.java
@@ -3,10 +3,11 @@ package com.dnd.Exercise.domain.field.dto.response;
 import com.dnd.Exercise.domain.field.entity.WinStatus;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-@Getter
+@Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
@@ -23,4 +24,14 @@ public class GetFieldExerciseSummaryRes {
     private String opponentFieldName;
 
     private WinStatus winStatus;
+
+    public GetFieldExerciseSummaryRes(int totalRecordCount, int goalAchievedCount,
+            int totalBurnedCalorie, int totalExerciseTimeMinute) {
+        this.totalRecordCount = totalRecordCount;
+        this.goalAchievedCount = goalAchievedCount;
+        this.totalBurnedCalorie = totalBurnedCalorie;
+        this.totalExerciseTimeMinute = totalExerciseTimeMinute;
+        this.opponentFieldName = null;
+        this.winStatus = null;
+    }
 }

--- a/src/main/java/com/dnd/Exercise/domain/field/dto/response/GetRankingRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/dto/response/GetRankingRes.java
@@ -1,9 +1,15 @@
 package com.dnd.Exercise.domain.field.dto.response;
 
 import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class GetRankingRes {
 
     private List<RankingDto> exerciseTimeRanking;

--- a/src/main/java/com/dnd/Exercise/domain/field/dto/response/RankingDto.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/dto/response/RankingDto.java
@@ -1,13 +1,17 @@
 package com.dnd.Exercise.domain.field.dto.response;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class RankingDto {
 
     private Long userId;
 
     private String profileImg;
 
-    private int value;
+    private Integer value;
 }

--- a/src/main/java/com/dnd/Exercise/domain/field/entity/RankCriterion.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/entity/RankCriterion.java
@@ -1,0 +1,8 @@
+package com.dnd.Exercise.domain.field.entity;
+
+public enum RankCriterion {
+    RECORD_COUNT,
+    GOAL_ACHIEVED,
+    BURNED_CALORIE,
+    EXERCISE_TIME
+}

--- a/src/main/java/com/dnd/Exercise/domain/field/service/FieldService.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/service/FieldService.java
@@ -2,13 +2,14 @@ package com.dnd.Exercise.domain.field.service;
 
 import com.dnd.Exercise.domain.field.dto.request.CreateFieldReq;
 import com.dnd.Exercise.domain.field.dto.request.FindAllFieldsCond;
-import com.dnd.Exercise.domain.field.dto.request.GetFieldExerciseSummaryReq;
+import com.dnd.Exercise.domain.field.dto.request.FieldSideDateReq;
 import com.dnd.Exercise.domain.field.dto.request.UpdateFieldInfoReq;
 import com.dnd.Exercise.domain.field.dto.request.UpdateFieldProfileReq;
 import com.dnd.Exercise.domain.field.dto.response.AutoMatchingRes;
 import com.dnd.Exercise.domain.field.dto.response.FindAllFieldsRes;
 import com.dnd.Exercise.domain.field.dto.response.FindFieldRes;
 import com.dnd.Exercise.domain.field.dto.response.GetFieldExerciseSummaryRes;
+import com.dnd.Exercise.domain.field.dto.response.GetRankingRes;
 import com.dnd.Exercise.domain.field.entity.FieldType;
 import com.dnd.Exercise.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
@@ -29,5 +30,7 @@ public interface FieldService {
 
     AutoMatchingRes autoMatching(FieldType fieldType, User user);
 
-    GetFieldExerciseSummaryRes getFieldExerciseSummary(User user, Long fieldId, GetFieldExerciseSummaryReq summaryReq);
+    GetFieldExerciseSummaryRes getFieldExerciseSummary(User user, Long fieldId, FieldSideDateReq summaryReq);
+
+    GetRankingRes getTeamRanking(User user, Long fieldId, FieldSideDateReq teamRankingReq);
 }

--- a/src/main/java/com/dnd/Exercise/domain/field/service/FieldService.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/service/FieldService.java
@@ -12,6 +12,7 @@ import com.dnd.Exercise.domain.field.dto.response.GetFieldExerciseSummaryRes;
 import com.dnd.Exercise.domain.field.dto.response.GetRankingRes;
 import com.dnd.Exercise.domain.field.entity.FieldType;
 import com.dnd.Exercise.domain.user.entity.User;
+import java.time.LocalDate;
 import org.springframework.data.domain.Pageable;
 
 public interface FieldService {
@@ -33,4 +34,6 @@ public interface FieldService {
     GetFieldExerciseSummaryRes getFieldExerciseSummary(User user, Long fieldId, FieldSideDateReq summaryReq);
 
     GetRankingRes getTeamRanking(User user, Long fieldId, FieldSideDateReq teamRankingReq);
+
+    GetRankingRes getDuelRanking(User user, Long fieldId, LocalDate date);
 }

--- a/src/main/java/com/dnd/Exercise/domain/field/service/FieldService.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/service/FieldService.java
@@ -41,4 +41,6 @@ public interface FieldService {
     GetRankingRes getDuelRanking(User user, Long fieldId, LocalDate date);
 
     List<FindFieldRecordDto> findAllFieldRecords(User user, Long fieldId, FindAllFieldRecordsReq recordsReq);
+
+    FindFieldRecordDto findFieldRecord(User user, Long fieldId, Long exerciseId);
 }

--- a/src/main/java/com/dnd/Exercise/domain/field/service/FieldService.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/service/FieldService.java
@@ -1,18 +1,21 @@
 package com.dnd.Exercise.domain.field.service;
 
 import com.dnd.Exercise.domain.field.dto.request.CreateFieldReq;
+import com.dnd.Exercise.domain.field.dto.request.FindAllFieldRecordsReq;
 import com.dnd.Exercise.domain.field.dto.request.FindAllFieldsCond;
 import com.dnd.Exercise.domain.field.dto.request.FieldSideDateReq;
 import com.dnd.Exercise.domain.field.dto.request.UpdateFieldInfoReq;
 import com.dnd.Exercise.domain.field.dto.request.UpdateFieldProfileReq;
 import com.dnd.Exercise.domain.field.dto.response.AutoMatchingRes;
 import com.dnd.Exercise.domain.field.dto.response.FindAllFieldsRes;
+import com.dnd.Exercise.domain.field.dto.response.FindFieldRecordDto;
 import com.dnd.Exercise.domain.field.dto.response.FindFieldRes;
 import com.dnd.Exercise.domain.field.dto.response.GetFieldExerciseSummaryRes;
 import com.dnd.Exercise.domain.field.dto.response.GetRankingRes;
 import com.dnd.Exercise.domain.field.entity.FieldType;
 import com.dnd.Exercise.domain.user.entity.User;
 import java.time.LocalDate;
+import java.util.List;
 import org.springframework.data.domain.Pageable;
 
 public interface FieldService {
@@ -36,4 +39,6 @@ public interface FieldService {
     GetRankingRes getTeamRanking(User user, Long fieldId, FieldSideDateReq teamRankingReq);
 
     GetRankingRes getDuelRanking(User user, Long fieldId, LocalDate date);
+
+    List<FindFieldRecordDto> findAllFieldRecords(User user, Long fieldId, FindAllFieldRecordsReq recordsReq);
 }

--- a/src/main/java/com/dnd/Exercise/domain/field/service/FieldService.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/service/FieldService.java
@@ -2,11 +2,13 @@ package com.dnd.Exercise.domain.field.service;
 
 import com.dnd.Exercise.domain.field.dto.request.CreateFieldReq;
 import com.dnd.Exercise.domain.field.dto.request.FindAllFieldsCond;
+import com.dnd.Exercise.domain.field.dto.request.GetFieldExerciseSummaryReq;
 import com.dnd.Exercise.domain.field.dto.request.UpdateFieldInfoReq;
 import com.dnd.Exercise.domain.field.dto.request.UpdateFieldProfileReq;
 import com.dnd.Exercise.domain.field.dto.response.AutoMatchingRes;
 import com.dnd.Exercise.domain.field.dto.response.FindAllFieldsRes;
 import com.dnd.Exercise.domain.field.dto.response.FindFieldRes;
+import com.dnd.Exercise.domain.field.dto.response.GetFieldExerciseSummaryRes;
 import com.dnd.Exercise.domain.field.entity.FieldType;
 import com.dnd.Exercise.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
@@ -26,4 +28,6 @@ public interface FieldService {
     void deleteFieldId(Long id, User user);
 
     AutoMatchingRes autoMatching(FieldType fieldType, User user);
+
+    GetFieldExerciseSummaryRes getFieldExerciseSummary(User user, Long fieldId, GetFieldExerciseSummaryReq summaryReq);
 }

--- a/src/main/java/com/dnd/Exercise/domain/field/service/FieldServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/service/FieldServiceImpl.java
@@ -205,16 +205,17 @@ public class FieldServiceImpl implements FieldService{
 
         List<Integer> mySummary = fetchFieldSummary(fieldId, targetDate);
 
-        GetFieldExerciseSummaryRes.GetFieldExerciseSummaryResBuilder summaryResBuilder = initSummaryBuilder(mySummary);
+        GetFieldExerciseSummaryRes summaryRes = initSummary(mySummary);
 
         if (isHome(fieldSide) && opponentField != null) {
             List<Integer> opponentSummary = fetchFieldSummary(opponentField.getId(), targetDate);
 
             WinStatus winStatus = compareSummaries(mySummary, opponentSummary);
-            summaryResBuilder = summaryResBuilder.winStatus(winStatus).opponentFieldName(opponentField.getName());
+            summaryRes.setWinStatus(winStatus);
+            summaryRes.setOpponentFieldName(opponentField.getName());
         }
 
-        return summaryResBuilder.build();
+        return summaryRes;
     }
 
     @Override
@@ -316,12 +317,9 @@ public class FieldServiceImpl implements FieldService{
         return List.of(totalRecordCount, goalAchievementCount, totalExerciseTimeMinute, totalBurnedCalorie);
     }
 
-    private GetFieldExerciseSummaryRes.GetFieldExerciseSummaryResBuilder initSummaryBuilder(List<Integer> summary) {
-        return GetFieldExerciseSummaryRes.builder()
-                .totalRecordCount(summary.get(0))
-                .goalAchievedCount(summary.get(1))
-                .totalBurnedCalorie(summary.get(2))
-                .totalExerciseTimeMinute(summary.get(3));
+    private GetFieldExerciseSummaryRes initSummary(List<Integer> summary) {
+        return new GetFieldExerciseSummaryRes(
+                summary.get(0), summary.get(1), summary.get(3), summary.get(2));
     }
 
     private WinStatus compareSummaries(List<Integer> mySummary, List<Integer> opponentSummary) {

--- a/src/main/java/com/dnd/Exercise/domain/field/service/FieldServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/service/FieldServiceImpl.java
@@ -1,13 +1,20 @@
 package com.dnd.Exercise.domain.field.service;
 
+import static com.dnd.Exercise.domain.field.entity.FieldSide.AWAY;
+import static com.dnd.Exercise.domain.field.entity.FieldSide.HOME;
 import static com.dnd.Exercise.domain.field.entity.FieldStatus.COMPLETED;
 import static com.dnd.Exercise.domain.field.entity.FieldStatus.IN_PROGRESS;
 import static com.dnd.Exercise.domain.field.entity.FieldStatus.RECRUITING;
 import static com.dnd.Exercise.global.error.dto.ErrorCode.*;
 
+import com.dnd.Exercise.domain.activityRing.entity.ActivityRing;
+import com.dnd.Exercise.domain.activityRing.repository.ActivityRingRepository;
+import com.dnd.Exercise.domain.exercise.entity.Exercise;
+import com.dnd.Exercise.domain.exercise.repository.ExerciseRepository;
 import com.dnd.Exercise.domain.field.dto.FieldMapper;
 import com.dnd.Exercise.domain.field.dto.request.CreateFieldReq;
 import com.dnd.Exercise.domain.field.dto.request.FindAllFieldsCond;
+import com.dnd.Exercise.domain.field.dto.request.GetFieldExerciseSummaryReq;
 import com.dnd.Exercise.domain.field.dto.request.UpdateFieldInfoReq;
 import com.dnd.Exercise.domain.field.dto.request.UpdateFieldProfileReq;
 import com.dnd.Exercise.domain.field.dto.response.AutoMatchingRes;
@@ -15,18 +22,24 @@ import com.dnd.Exercise.domain.field.dto.response.FieldDto;
 import com.dnd.Exercise.domain.field.dto.response.FindAllFieldsDto;
 import com.dnd.Exercise.domain.field.dto.response.FindAllFieldsRes;
 import com.dnd.Exercise.domain.field.dto.response.FindFieldRes;
+import com.dnd.Exercise.domain.field.dto.response.GetFieldExerciseSummaryRes;
+import com.dnd.Exercise.domain.field.dto.response.GetFieldExerciseSummaryRes.GetFieldExerciseSummaryResBuilder;
 import com.dnd.Exercise.domain.field.entity.Field;
+import com.dnd.Exercise.domain.field.entity.FieldSide;
 import com.dnd.Exercise.domain.field.entity.FieldStatus;
 import com.dnd.Exercise.domain.field.entity.FieldType;
+import com.dnd.Exercise.domain.field.entity.WinStatus;
 import com.dnd.Exercise.domain.field.repository.FieldRepository;
 import com.dnd.Exercise.domain.user.entity.User;
 import com.dnd.Exercise.domain.userField.entity.UserField;
 import com.dnd.Exercise.domain.userField.repository.UserFieldRepository;
 import com.dnd.Exercise.global.error.exception.BusinessException;
+import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -43,6 +56,8 @@ public class FieldServiceImpl implements FieldService{
     private final FieldRepository fieldRepository;
     private final UserFieldRepository userFieldRepository;
     private final FieldMapper fieldMapper;
+    private final ActivityRingRepository activityRingRepository;
+    private final ExerciseRepository exerciseRepository;
 
     @Transactional
     @Override
@@ -158,6 +173,113 @@ public class FieldServiceImpl implements FieldService{
                 .orElseThrow(() -> new BusinessException(NO_SIMILAR_FIELD_FOUND));
 
         return fieldMapper.toAutoMatchingRes(resultField);
+    }
+
+    /**
+     * HOME & opponent==null - 나의 필드 요약 정보 제공
+     * HOME & opponent!=null - 나의 필드 요약 정보, 승리 여부, 상대방 필드 이름 제공
+     * AWAY & opponent==null - 예외
+     * AWAY & opponent!=null - 상대 필드 요약 정보 제공
+     */
+    @Override
+    public GetFieldExerciseSummaryRes getFieldExerciseSummary(User user, Long fieldId, GetFieldExerciseSummaryReq summaryReq) {
+        Field field = validateFieldAccess(user, fieldId);
+        Field opponentField = field.getOpponent();
+
+        FieldSide fieldSide = summaryReq.getFieldSide();
+        LocalDate targetDate = summaryReq.getDate();
+
+        if (isAway(fieldSide) && opponentField == null) {
+            throw new BusinessException(OPPONENT_NOT_FOUND);
+        }
+
+        List<Integer> mySummary = fetchFieldSummary(fieldId, targetDate);
+
+        GetFieldExerciseSummaryResBuilder summaryResBuilder = initSummaryBuilder(mySummary);
+
+        if (isHome(fieldSide) && opponentField != null) {
+            List<Integer> opponentSummary = fetchFieldSummary(opponentField.getId(), targetDate);
+
+            WinStatus winStatus = compareSummaries(mySummary, opponentSummary);
+            summaryResBuilder = summaryResBuilder.winStatus(winStatus).opponentFieldName(opponentField.getName());
+        }
+
+        return summaryResBuilder.build();
+    }
+
+    private boolean isAway(FieldSide fieldSide) {
+        return AWAY.equals(fieldSide);
+    }
+
+    private boolean isHome(FieldSide fieldSide) {
+        return HOME.equals(fieldSide);
+    }
+
+    private List<Integer> fetchFieldSummary(Long fieldId, LocalDate targetDate) {
+        List<Long> memberIds = getMemberIdsForField(fieldId);
+        List<ActivityRing> activityRings = getActivityRings(targetDate, memberIds);
+        List<Exercise> exercises = getExercises(targetDate, memberIds);
+
+        return calculateSummary(activityRings, exercises);
+    }
+
+    private List<Integer> calculateSummary(List<ActivityRing> activityRings, List<Exercise> exercises) {
+        int totalRecordCount = exercises.size();
+        int goalAchievementCount = (int) activityRings.stream().filter(ActivityRing::getIsGoalAchieved).count();
+        int totalExerciseTimeMinute = exercises.stream().mapToInt(Exercise::getDurationMinute).sum();
+        int totalBurnedCalorie = activityRings.stream().mapToInt(ActivityRing::getBurnedCalorie).sum();
+
+        return List.of(totalRecordCount, goalAchievementCount, totalExerciseTimeMinute, totalBurnedCalorie);
+    }
+
+    private GetFieldExerciseSummaryResBuilder initSummaryBuilder(List<Integer> summary) {
+        return GetFieldExerciseSummaryRes.builder()
+                .totalRecordCount(summary.get(0))
+                .goalAchievedCount(summary.get(1))
+                .totalBurnedCalorie(summary.get(2))
+                .totalExerciseTimeMinute(summary.get(3));
+    }
+
+    private WinStatus compareSummaries(List<Integer> mySummary, List<Integer> opponentSummary) {
+        int result = IntStream.range(0, mySummary.size())
+                .map(i -> Integer.compare(mySummary.get(i), opponentSummary.get(i)))
+                .sum();
+
+        if (result > 0) return WinStatus.WIN;
+        if (result < 0) return WinStatus.LOSE;
+        return WinStatus.DRAW;
+    }
+
+    private Field validateFieldAccess(User user, Long fieldId) {
+        Field field = getField(fieldId);
+        validateIsMember(user, field);
+        validateFieldStatus(field);
+        return field;
+    }
+
+    private void validateIsMember(User user, Field field) {
+        if (!userFieldRepository.existsByFieldAndUser(field, user)) {
+            throw new BusinessException(FORBIDDEN);
+        }
+    }
+
+    private void validateFieldStatus(Field field) {
+        if (field.getFieldStatus() == RECRUITING) {
+            throw new BusinessException(RECRUITING_YET);
+        }
+    }
+
+    private List<Long> getMemberIdsForField(Long fieldId) {
+        List<UserField> allMembers = userFieldRepository.findAllByField(fieldId);
+        return allMembers.stream().map(UserField::getId).collect(Collectors.toList());
+    }
+
+    private List<ActivityRing> getActivityRings(LocalDate date, List<Long> memberIds) {
+        return activityRingRepository.findAllByDateAndUserIdIn(date, memberIds);
+    }
+
+    private List<Exercise> getExercises(LocalDate date, List<Long> memberIds) {
+        return exerciseRepository.findAllByExerciseDateAndUserIdIn(date, memberIds);
     }
 
     private Boolean isFull(Field field) {

--- a/src/main/java/com/dnd/Exercise/domain/field/service/FieldServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/service/FieldServiceImpl.java
@@ -225,8 +225,24 @@ public class FieldServiceImpl implements FieldService{
             field = field.getOpponent();
         }
         Long targetId = field.getId();
-        List<Long> memberIds = getMemberIdsForField(targetId);
+        List<Long> memberIds = getMemberIds(targetId);
 
+        return getGetRankingRes(date, memberIds);
+    }
+
+    @Override
+    public GetRankingRes getDuelRanking(User user, Long fieldId, LocalDate date) {
+        Field field = validateFieldAccess(user, fieldId);
+        Long opponentFieldId = field.getOpponent().getId();
+
+        Long memberId = getMemberIds(fieldId).get(0);
+        Long opponentMemberId = getMemberIds(opponentFieldId).get(0);
+        List<Long> memberIds = List.of(memberId, opponentMemberId);
+
+        return getGetRankingRes(date, memberIds);
+    }
+
+    private GetRankingRes getGetRankingRes(LocalDate date, List<Long> memberIds) {
         return GetRankingRes.builder()
                 .recordCountRanking(getRankingByCriteria(RECORD_COUNT, date, memberIds))
                 .exerciseTimeRanking(getRankingByCriteria(EXERCISE_TIME, date, memberIds))
@@ -252,7 +268,7 @@ public class FieldServiceImpl implements FieldService{
     }
 
     private List<Integer> fetchFieldSummary(Long fieldId, LocalDate targetDate) {
-        List<Long> memberIds = getMemberIdsForField(fieldId);
+        List<Long> memberIds = getMemberIds(fieldId);
         List<ActivityRing> activityRings = getActivityRings(targetDate, memberIds);
         List<Exercise> exercises = getExercises(targetDate, memberIds);
 
@@ -305,7 +321,7 @@ public class FieldServiceImpl implements FieldService{
         }
     }
 
-    private List<Long> getMemberIdsForField(Long fieldId) {
+    private List<Long> getMemberIds(Long fieldId) {
         List<UserField> allMembers = userFieldRepository.findAllByField(fieldId);
         return allMembers.stream().map(userField -> userField.getUser().getId()).collect(Collectors.toList());
     }

--- a/src/main/java/com/dnd/Exercise/domain/field/service/FieldServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/service/FieldServiceImpl.java
@@ -261,6 +261,19 @@ public class FieldServiceImpl implements FieldService{
 
     }
 
+    @Override
+    public FindFieldRecordDto findFieldRecord(User user, Long fieldId, Long exerciseId) {
+        Field field = validateFieldAccess(user, fieldId);
+        Exercise exercise = exerciseRepository.findWithUserById(exerciseId)
+                .orElseThrow(() -> new BusinessException(NOT_FOUND));
+        validateIsMember(exercise.getUser(), field);
+
+        FindFieldRecordDto findFieldRecordDto = fieldMapper.toFindFieldRecordDto(exercise);
+        findFieldRecordDto.setIsLeader(field.getLeaderId().equals(user.getId()));
+
+        return findFieldRecordDto;
+    }
+
     private GetRankingRes getGetRankingRes(LocalDate date, List<Long> memberIds) {
         return GetRankingRes.builder()
                 .recordCountRanking(getRankingByCriteria(RECORD_COUNT, date, memberIds))

--- a/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
+++ b/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
@@ -32,7 +32,9 @@ public enum ErrorCode {
 
     RECRUITING_YET(HttpStatus.BAD_REQUEST, "F-005", "현재 팀원 모집 중입니다."),
 
-    NO_SIMILAR_FIELD_FOUND(HttpStatus.NOT_FOUND, "F-006", "비슷한 조건의 필드가 없습니다.");
+    NO_SIMILAR_FIELD_FOUND(HttpStatus.NOT_FOUND, "F-006", "비슷한 조건의 필드가 없습니다."),
+
+    OPPONENT_NOT_FOUND(HttpStatus.NOT_FOUND, "F-007", "매칭된 상대 필드가 없습니다.");
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
운동 하루 요약, 랭킹 조회 등 기록 페이지에서 사용되는 API를 구현했습니다.

## 📋 변경 사항
- API 구현
    - getFiledExerciseSummary
    - getTeamRanking
    - getDuelRanking
    - findAllFieldRecords
    - findFieldRecord

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 연결된 이슈 Close
close #33 
