### PR TITLE
Feat: 회원가입, 로그인 기초 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,9 @@ dependencies {
 	// MapStruct
 	implementation 'org.mapstruct:mapstruct:1.5.3.Final'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 }
 
 jar {

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 jar {

--- a/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
@@ -32,8 +32,9 @@ public class AuthController {
 
     @ApiOperation(value = "로그인 🔐", notes = "일반 로그인 시 사용합니다.")
     @PostMapping("/login")
-    public ResponseEntity<TokenRes> login(@RequestBody LoginReq loginReq) {
-        return ResponseDto.ok(new TokenRes());
+    public ResponseEntity<TokenRes> login(@RequestBody @Valid LoginReq loginReq) {
+        TokenRes token = authService.login(loginReq);
+        return ResponseDto.ok(token);
     }
 
     @ApiOperation(value = "회원가입 시 중복된 id 체크 🔐", notes = "사용 가능한 id 인지 체크합니다.")

--- a/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
@@ -5,20 +5,28 @@ import com.dnd.Exercise.domain.auth.dto.request.RefreshReq;
 import com.dnd.Exercise.domain.auth.dto.request.SignUpReq;
 import com.dnd.Exercise.domain.auth.dto.response.AccessTokenRes;
 import com.dnd.Exercise.domain.auth.dto.response.TokenRes;
+import com.dnd.Exercise.domain.auth.service.AuthService;
 import com.dnd.Exercise.global.common.ResponseDto;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
+
 @Api(tags = "인증 🔐")
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
 
+    private final AuthService authService;
+
     @ApiOperation(value = "회원가입 🔐", notes = "일반 회원가입 시 사용합니다.")
     @PostMapping("/sign-up")
-    public ResponseEntity<String> signUp(@RequestBody SignUpReq signUpReq) {
+    public ResponseEntity<String> signUp(@RequestBody @Valid SignUpReq signUpReq) {
+        authService.signUp(signUpReq);
         return ResponseDto.ok("회원가입 완료");
     }
 

--- a/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
@@ -51,7 +51,8 @@ public class AuthController {
     @ApiOperation(value = "access 토큰 만료 시 재발급 🔐", notes = "refresh 토큰으로 access 토큰을 갱신합니다.")
     @PostMapping("/refresh")
     public ResponseEntity<AccessTokenRes> refresh(@RequestBody RefreshReq refreshReq) {
-        return ResponseDto.ok(new AccessTokenRes());
+        AccessTokenRes token = authService.refresh(refreshReq);
+        return ResponseDto.ok(token);
     }
 
     @ApiOperation(value = "로그아웃 🔐", notes = "")

--- a/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.dnd.Exercise.domain.auth.dto.request.SignUpReq;
 import com.dnd.Exercise.domain.auth.dto.response.AccessTokenRes;
 import com.dnd.Exercise.domain.auth.dto.response.TokenRes;
 import com.dnd.Exercise.domain.auth.service.AuthService;
+import com.dnd.Exercise.domain.user.entity.User;
 import com.dnd.Exercise.global.common.ResponseDto;
 import com.dnd.Exercise.global.error.dto.ErrorCode;
 import com.dnd.Exercise.global.error.exception.BusinessException;
@@ -58,8 +59,8 @@ public class AuthController {
 
     @ApiOperation(value = "로그아웃 🔐", notes = "")
     @GetMapping("/logout")
-    public ResponseEntity<String> logout(@AuthenticationPrincipal Long userId) {
-        authService.logout(userId);
+    public ResponseEntity<String> logout(@AuthenticationPrincipal User user) {
+        authService.logout(user.getId());
         return ResponseDto.ok("로그아웃 성공");
     }
 

--- a/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
@@ -7,6 +7,8 @@ import com.dnd.Exercise.domain.auth.dto.response.AccessTokenRes;
 import com.dnd.Exercise.domain.auth.dto.response.TokenRes;
 import com.dnd.Exercise.domain.auth.service.AuthService;
 import com.dnd.Exercise.global.common.ResponseDto;
+import com.dnd.Exercise.global.error.dto.ErrorCode;
+import com.dnd.Exercise.global.error.exception.BusinessException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +28,9 @@ public class AuthController {
     @ApiOperation(value = "회원가입 🔐", notes = "일반 회원가입 시 사용합니다.")
     @PostMapping("/sign-up")
     public ResponseEntity<String> signUp(@RequestBody @Valid SignUpReq signUpReq) {
+        if(!authService.checkUidAvailable(signUpReq.getUid())) {
+            throw new BusinessException(ErrorCode.ID_ALREADY_EXISTS);
+        }
         authService.signUp(signUpReq);
         return ResponseDto.ok("회원가입 완료");
     }
@@ -40,7 +45,7 @@ public class AuthController {
     @ApiOperation(value = "회원가입 시 중복된 id 체크 🔐", notes = "사용 가능한 id 인지 체크합니다.")
     @GetMapping("/id-available")
     public ResponseEntity<Boolean> idAvailable(@RequestParam String uid) {
-        return ResponseDto.ok(true);
+        return ResponseDto.ok(authService.checkUidAvailable(uid));
     }
 
     @ApiOperation(value = "access 토큰 만료 시 재발급 🔐", notes = "refresh 토큰으로 access 토큰을 갱신합니다.")

--- a/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
@@ -12,6 +12,8 @@ import com.dnd.Exercise.global.error.dto.ErrorCode;
 import com.dnd.Exercise.global.error.exception.BusinessException;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -28,6 +30,10 @@ public class AuthController {
     private final AuthService authService;
 
     @ApiOperation(value = "회원가입 🔐", notes = "일반 회원가입 시 사용합니다.")
+    @ApiResponses({
+            @ApiResponse(code=200, message="회원가입 완료"),
+            @ApiResponse(code=400, message="이미 사용중인 아이디 입니다.")
+    })
     @PostMapping("/sign-up")
     public ResponseEntity<String> signUp(@RequestBody @Valid SignUpReq signUpReq) {
         if(!authService.checkUidAvailable(signUpReq.getUid())) {
@@ -37,7 +43,10 @@ public class AuthController {
         return ResponseDto.ok("회원가입 완료");
     }
 
-    @ApiOperation(value = "로그인 🔐", notes = "일반 로그인 시 사용합니다.")
+    @ApiOperation(value = "로그인 🔐", notes = "일반 로그인 시 사용합니다. <br> 발급받은 access 토큰은 추후 요청 시 Authorization 헤더에 'Bearer 토큰' 형태로 전송합니다.")
+    @ApiResponses({
+            @ApiResponse(code=400, message="아이디 또는 비밀번호를 잘못 입력하였습니다.")
+    })
     @PostMapping("/login")
     public ResponseEntity<TokenRes> login(@RequestBody @Valid LoginReq loginReq) {
         TokenRes token = authService.login(loginReq);
@@ -51,6 +60,9 @@ public class AuthController {
     }
 
     @ApiOperation(value = "access 토큰 만료 시 재발급 🔐", notes = "refresh 토큰으로 access 토큰을 갱신합니다.")
+    @ApiResponses({
+            @ApiResponse(code=400, message="유효하지 않은 refresh 토큰 입니다.")
+    })
     @PostMapping("/refresh")
     public ResponseEntity<AccessTokenRes> refresh(@RequestBody RefreshReq refreshReq) {
         AccessTokenRes token = authService.refresh(refreshReq);
@@ -58,6 +70,9 @@ public class AuthController {
     }
 
     @ApiOperation(value = "로그아웃 🔐", notes = "")
+    @ApiResponses({
+            @ApiResponse(code=200, message="로그아웃 성공")
+    })
     @GetMapping("/logout")
     public ResponseEntity<String> logout(@AuthenticationPrincipal User user) {
         authService.logout(user.getId());

--- a/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/controller/AuthController.java
@@ -13,6 +13,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
@@ -57,7 +58,8 @@ public class AuthController {
 
     @ApiOperation(value = "로그아웃 🔐", notes = "")
     @GetMapping("/logout")
-    public ResponseEntity<String> logout() {
+    public ResponseEntity<String> logout(@AuthenticationPrincipal Long userId) {
+        authService.logout(userId);
         return ResponseDto.ok("로그아웃 성공");
     }
 

--- a/src/main/java/com/dnd/Exercise/domain/auth/dto/request/LoginReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/dto/request/LoginReq.java
@@ -3,12 +3,16 @@ package com.dnd.Exercise.domain.auth.dto.request;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+
 @Getter
 @NoArgsConstructor
 public class LoginReq {
 
+    @NotBlank(message = "아이디를 입력해주세요.")
     private String uid;
 
+    @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 
 }

--- a/src/main/java/com/dnd/Exercise/domain/auth/dto/request/SignUpReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/dto/request/SignUpReq.java
@@ -1,6 +1,7 @@
 package com.dnd.Exercise.domain.auth.dto.request;
 
 import com.dnd.Exercise.domain.field.entity.SkillLevel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,17 +10,22 @@ import javax.validation.constraints.NotBlank;
 @Getter
 @NoArgsConstructor
 public class SignUpReq {
+    @ApiModelProperty(value = "아이디", required = true, example = "hana_bi")
     @NotBlank(message = "아이디를 입력해주세요.")
     private String uid;
 
+    @ApiModelProperty(value = "비밀번호", required = true)
     @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 
+    @ApiModelProperty(value = "전화번호", required = true, example = "01012345678")
     @NotBlank(message = "전화번호를 입력해주세요.")
     private String phoneNum;
 
+    @ApiModelProperty(value = "이름", required = true , example = "정지민")
     @NotBlank(message = "이름을 입력해주세요.")
     private String name;
 
+    @ApiModelProperty(value = "운동레벨")
     private SkillLevel skillLevel;
 }

--- a/src/main/java/com/dnd/Exercise/domain/auth/dto/request/SignUpReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/dto/request/SignUpReq.java
@@ -1,20 +1,24 @@
 package com.dnd.Exercise.domain.auth.dto.request;
 
 import com.dnd.Exercise.domain.field.entity.SkillLevel;
-import com.dnd.Exercise.domain.user.entity.LoginType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
 
 @Getter
 @NoArgsConstructor
 public class SignUpReq {
-
+    @NotBlank(message = "아이디를 입력해주세요.")
     private String uid;
 
+    @NotBlank(message = "비밀번호를 입력해주세요.")
     private String password;
 
+    @NotBlank(message = "전화번호를 입력해주세요.")
     private String phoneNum;
 
+    @NotBlank(message = "이름을 입력해주세요.")
     private String name;
 
     private SkillLevel skillLevel;

--- a/src/main/java/com/dnd/Exercise/domain/auth/dto/response/AccessTokenRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/dto/response/AccessTokenRes.java
@@ -1,10 +1,14 @@
 package com.dnd.Exercise.domain.auth.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class AccessTokenRes {
     private String accessToken;
 }

--- a/src/main/java/com/dnd/Exercise/domain/auth/dto/response/TokenRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/dto/response/TokenRes.java
@@ -1,10 +1,14 @@
 package com.dnd.Exercise.domain.auth.dto.response;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class TokenRes {
 
     private String accessToken;

--- a/src/main/java/com/dnd/Exercise/domain/auth/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/repository/RefreshTokenRedisRepository.java
@@ -2,7 +2,6 @@ package com.dnd.Exercise.domain.auth.repository;
 
 import com.dnd.Exercise.global.jwt.RefreshToken;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.stereotype.Repository;
 
 public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, String> {
     RefreshToken findByUserId(long userId);

--- a/src/main/java/com/dnd/Exercise/domain/auth/repository/RefreshTokenRedisRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/repository/RefreshTokenRedisRepository.java
@@ -4,7 +4,6 @@ import com.dnd.Exercise.global.jwt.RefreshToken;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
-public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
-
+public interface RefreshTokenRedisRepository extends CrudRepository<RefreshToken, String> {
+    RefreshToken findByUserId(long userId);
 }

--- a/src/main/java/com/dnd/Exercise/domain/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,10 @@
+package com.dnd.Exercise.domain.auth.repository;
+
+import com.dnd.Exercise.global.jwt.RefreshToken;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
+
+}

--- a/src/main/java/com/dnd/Exercise/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/service/AuthService.java
@@ -11,4 +11,5 @@ public interface AuthService {
     TokenRes login(LoginReq loginReq);
     boolean checkUidAvailable(String uid);
     AccessTokenRes refresh(RefreshReq refreshReq);
+    void logout(Long userId);
 }

--- a/src/main/java/com/dnd/Exercise/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/service/AuthService.java
@@ -1,7 +1,10 @@
 package com.dnd.Exercise.domain.auth.service;
 
+import com.dnd.Exercise.domain.auth.dto.request.LoginReq;
 import com.dnd.Exercise.domain.auth.dto.request.SignUpReq;
+import com.dnd.Exercise.domain.auth.dto.response.TokenRes;
 
 public interface AuthService {
     void signUp(SignUpReq signUpReq);
+    TokenRes login(LoginReq loginReq);
 }

--- a/src/main/java/com/dnd/Exercise/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/service/AuthService.java
@@ -7,4 +7,5 @@ import com.dnd.Exercise.domain.auth.dto.response.TokenRes;
 public interface AuthService {
     void signUp(SignUpReq signUpReq);
     TokenRes login(LoginReq loginReq);
+    boolean checkUidAvailable(String uid);
 }

--- a/src/main/java/com/dnd/Exercise/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/service/AuthService.java
@@ -1,0 +1,7 @@
+package com.dnd.Exercise.domain.auth.service;
+
+import com.dnd.Exercise.domain.auth.dto.request.SignUpReq;
+
+public interface AuthService {
+    void signUp(SignUpReq signUpReq);
+}

--- a/src/main/java/com/dnd/Exercise/domain/auth/service/AuthService.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/service/AuthService.java
@@ -1,11 +1,14 @@
 package com.dnd.Exercise.domain.auth.service;
 
 import com.dnd.Exercise.domain.auth.dto.request.LoginReq;
+import com.dnd.Exercise.domain.auth.dto.request.RefreshReq;
 import com.dnd.Exercise.domain.auth.dto.request.SignUpReq;
+import com.dnd.Exercise.domain.auth.dto.response.AccessTokenRes;
 import com.dnd.Exercise.domain.auth.dto.response.TokenRes;
 
 public interface AuthService {
     void signUp(SignUpReq signUpReq);
     TokenRes login(LoginReq loginReq);
     boolean checkUidAvailable(String uid);
+    AccessTokenRes refresh(RefreshReq refreshReq);
 }

--- a/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
@@ -78,4 +78,10 @@ public class AuthServiceImpl implements AuthService {
                 .build();
         return newAccessToken;
     }
+
+    @Override
+    public void logout(Long userId) {
+        RefreshToken token = refreshTokenRedisRepository.findByUserId(userId);
+        refreshTokenRedisRepository.deleteById(token.getRefreshToken());
+    }
 }

--- a/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
@@ -45,7 +45,8 @@ public class AuthServiceImpl implements AuthService {
             throw new BusinessException(ErrorCode.LOGIN_FAILED);
         }
         TokenRes token = TokenRes.builder()
-                .accessToken(jwtTokenProvider.createToken(user.getId()))
+                .accessToken(jwtTokenProvider.createAccessToken(user.getId()))
+                .refreshToken(jwtTokenProvider.createRefreshToken(user.getId()))
                 .build();
         return token;
     }

--- a/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
@@ -1,0 +1,32 @@
+package com.dnd.Exercise.domain.auth.service;
+
+import com.dnd.Exercise.domain.auth.dto.request.SignUpReq;
+import com.dnd.Exercise.domain.user.entity.LoginType;
+import com.dnd.Exercise.domain.user.entity.User;
+import com.dnd.Exercise.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AuthServiceImpl implements AuthService {
+
+    private final PasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public void signUp(SignUpReq signUpReq) {
+        userRepository.save(User.builder()
+                .uid(signUpReq.getUid())
+                .password(passwordEncoder.encode(signUpReq.getPassword()))
+                .phoneNum(signUpReq.getPhoneNum())
+                .name(signUpReq.getName())
+                .skillLevel(signUpReq.getSkillLevel())
+                .loginType(LoginType.MATCH_UP)
+                .build());
+    }
+}

--- a/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
@@ -49,4 +49,9 @@ public class AuthServiceImpl implements AuthService {
                 .build();
         return token;
     }
+
+    @Override
+    public boolean checkUidAvailable(String uid) {
+        return !userRepository.existsByUid(uid);
+    }
 }

--- a/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
@@ -5,7 +5,7 @@ import com.dnd.Exercise.domain.auth.dto.request.RefreshReq;
 import com.dnd.Exercise.domain.auth.dto.request.SignUpReq;
 import com.dnd.Exercise.domain.auth.dto.response.AccessTokenRes;
 import com.dnd.Exercise.domain.auth.dto.response.TokenRes;
-import com.dnd.Exercise.domain.auth.repository.RefreshTokenRepository;
+import com.dnd.Exercise.domain.auth.repository.RefreshTokenRedisRepository;
 import com.dnd.Exercise.domain.user.entity.LoginType;
 import com.dnd.Exercise.domain.user.entity.User;
 import com.dnd.Exercise.domain.user.repository.UserRepository;
@@ -28,7 +28,7 @@ public class AuthServiceImpl implements AuthService {
     private final UserRepository userRepository;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider jwtTokenProvider;
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
     @Override
     @Transactional
@@ -68,7 +68,7 @@ public class AuthServiceImpl implements AuthService {
         if (requestToken == null || !jwtTokenProvider.validateToken(requestToken)) {
             throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
         }
-        RefreshToken redisToken = refreshTokenRepository.findById(requestToken).orElseThrow(() -> new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN));
+        RefreshToken redisToken = refreshTokenRedisRepository.findById(requestToken).orElseThrow(() -> new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN));
         if ((redisToken.getUserId() != Long.parseLong(jwtTokenProvider.getUserId(requestToken)))) {
             throw new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN);
         }

--- a/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
@@ -26,7 +26,6 @@ public class AuthServiceImpl implements AuthService {
 
     private final PasswordEncoder passwordEncoder;
     private final UserRepository userRepository;
-    private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider jwtTokenProvider;
     private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 

--- a/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
@@ -10,9 +10,7 @@ import com.dnd.Exercise.global.error.dto.ErrorCode;
 import com.dnd.Exercise.global.error.exception.BusinessException;
 import com.dnd.Exercise.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -46,12 +44,8 @@ public class AuthServiceImpl implements AuthService {
         if (!passwordEncoder.matches(loginReq.getPassword(), user.getPassword())) {
             throw new BusinessException(ErrorCode.LOGIN_FAILED);
         }
-
-        UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(loginReq.getUid(), loginReq.getPassword());
-        Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-
         TokenRes token = TokenRes.builder()
-                .accessToken(jwtTokenProvider.createToken(authentication.getName()))
+                .accessToken(jwtTokenProvider.createToken(user.getId()))
                 .build();
         return token;
     }

--- a/src/main/java/com/dnd/Exercise/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/service/CustomUserDetailsService.java
@@ -15,7 +15,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return userRepository.findByUid(username)
+        return userRepository.findById(Long.parseLong(username))
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
     }
 }

--- a/src/main/java/com/dnd/Exercise/domain/auth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/service/CustomUserDetailsService.java
@@ -1,0 +1,21 @@
+package com.dnd.Exercise.domain.auth.service;
+
+import com.dnd.Exercise.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByUid(username)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
@@ -5,11 +5,16 @@ import javax.persistence.*;
 import com.dnd.Exercise.domain.field.entity.SkillLevel;
 import com.dnd.Exercise.global.common.BaseEntity;
 import lombok.*;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.HashSet;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class User extends BaseEntity {
+public class User extends BaseEntity implements UserDetails {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
@@ -49,6 +54,42 @@ public class User extends BaseEntity {
     private Boolean isNotificationAgreed;
 
     private Boolean isAppleLinked;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return new HashSet<GrantedAuthority>();
+    }
+
+
+    @Override
+    public String getUsername() {
+        return uid;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
 
     @Builder
     public User(String uid, String password, String phoneNum, String name, SkillLevel skillLevel, LoginType loginType) {

--- a/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
@@ -4,10 +4,11 @@ import javax.persistence.*;
 
 import com.dnd.Exercise.domain.field.entity.SkillLevel;
 import com.dnd.Exercise.global.common.BaseEntity;
-import lombok.Getter;
+import lombok.*;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -48,4 +49,14 @@ public class User extends BaseEntity {
     private Boolean isNotificationAgreed;
 
     private Boolean isAppleLinked;
+
+    @Builder
+    public User(String uid, String password, String phoneNum, String name, SkillLevel skillLevel, LoginType loginType) {
+        this.uid = uid;
+        this.password = password;
+        this.phoneNum = phoneNum;
+        this.name = name;
+        this.skillLevel = skillLevel;
+        this.loginType = loginType;
+    }
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
@@ -63,7 +63,7 @@ public class User extends BaseEntity implements UserDetails {
 
     @Override
     public String getUsername() {
-        return uid;
+        return id.toString();
     }
 
     @Override

--- a/src/main/java/com/dnd/Exercise/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/repository/UserRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUid(String uid);
+    Optional<User> findById(long id);
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package com.dnd.Exercise.domain.user.repository;
+
+import com.dnd.Exercise.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByUid(String uid);
+}

--- a/src/main/java/com/dnd/Exercise/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/repository/UserRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUid(String uid);
     Optional<User> findById(long id);
+    boolean existsByUid(String uid);
 }

--- a/src/main/java/com/dnd/Exercise/global/config/RedisConfig.java
+++ b/src/main/java/com/dnd/Exercise/global/config/RedisConfig.java
@@ -1,0 +1,23 @@
+package com.dnd.Exercise.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+
+@Configuration
+@EnableRedisRepositories
+public class RedisConfig {
+    @Value("${spring.redis.host}")
+    private String host;
+
+    @Value("${spring.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(host,port);
+    }
+}

--- a/src/main/java/com/dnd/Exercise/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/Exercise/global/config/SecurityConfig.java
@@ -1,18 +1,25 @@
 package com.dnd.Exercise.global.config;
 
+import com.dnd.Exercise.global.jwt.JwtAuthenticationFilter;
+import com.dnd.Exercise.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -23,9 +30,15 @@ public class SecurityConfig {
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .csrf().disable()
+                .httpBasic().disable()
+                .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
                 .authorizeRequests()
-                .antMatchers("/**").permitAll()
-                .anyRequest().authenticated();
+                .antMatchers("/auth/sign-up", "/auth/login").permitAll()
+                .anyRequest().authenticated()
+                .and()
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }
 }

--- a/src/main/java/com/dnd/Exercise/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/Exercise/global/config/SecurityConfig.java
@@ -5,12 +5,20 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http

--- a/src/main/java/com/dnd/Exercise/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/Exercise/global/config/SecurityConfig.java
@@ -19,6 +19,17 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private static final String[] PERMIT_URLS = {
+            "/health-check",
+            /* swagger */
+            "/v3/api-docs/**", "/swagger-ui/**", "/swagger-resources", "/swagger-resources/**",
+            "/configuration/ui", "/configuration/security",
+            "/swagger-ui.html",
+            "/webjars/**",
+            /* apis */
+            "/auth/sign-up", "/auth/login", "/auth/id-available", "/auth/refresh"
+    };
+
     private final JwtTokenProvider jwtTokenProvider;
 
     @Bean
@@ -34,7 +45,7 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers("/health-check", "/auth/sign-up", "/auth/login", "/auth/id-available", "/auth/refresh").permitAll()
+                .antMatchers(PERMIT_URLS).permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),

--- a/src/main/java/com/dnd/Exercise/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/Exercise/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers("/health-check", "/auth/sign-up", "/auth/login", "/auth/id-available").permitAll()
+                .antMatchers("/health-check", "/auth/sign-up", "/auth/login", "/auth/id-available", "/auth/refresh").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),

--- a/src/main/java/com/dnd/Exercise/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/Exercise/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers("/auth/sign-up", "/auth/login").permitAll()
+                .antMatchers("/health-check", "/auth/sign-up", "/auth/login").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),

--- a/src/main/java/com/dnd/Exercise/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/Exercise/global/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()
                 .authorizeRequests()
-                .antMatchers("/health-check", "/auth/sign-up", "/auth/login").permitAll()
+                .antMatchers("/health-check", "/auth/sign-up", "/auth/login", "/auth/id-available").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),

--- a/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
+++ b/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
@@ -26,6 +26,8 @@ public enum ErrorCode {
 
     ID_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "A-002", "이미 사용중인 아이디 입니다."),
 
+    INVALID_REFRESH_TOKEN(HttpStatus.BAD_REQUEST, "A-003", "유효하지 않은 refresh 토큰 입니다."),
+
     INVALID_STATUS(HttpStatus.BAD_REQUEST, "F-001", "진행 중, 완료된 필드에 대해서는 수정이 불가능합니다."),
 
     DELETE_FAILED(HttpStatus.BAD_REQUEST, "F-002", "완료된 필드에 대해서는 삭제가 불가능합니다."),

--- a/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
+++ b/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
@@ -22,6 +22,8 @@ public enum ErrorCode {
 
     FORBIDDEN(HttpStatus.FORBIDDEN, "C-006","접근 권한이 없습니다."),
 
+    LOGIN_FAILED(HttpStatus.BAD_REQUEST, "A-001", "아이디 또는 비밀번호를 잘못 입력하였습니다."),
+
     INVALID_STATUS(HttpStatus.BAD_REQUEST, "F-001", "진행 중, 완료된 필드에 대해서는 수정이 불가능합니다."),
 
     DELETE_FAILED(HttpStatus.BAD_REQUEST, "F-002", "완료된 필드에 대해서는 삭제가 불가능합니다."),

--- a/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
+++ b/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
@@ -24,6 +24,8 @@ public enum ErrorCode {
 
     LOGIN_FAILED(HttpStatus.BAD_REQUEST, "A-001", "아이디 또는 비밀번호를 잘못 입력하였습니다."),
 
+    ID_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "A-002", "이미 사용중인 아이디 입니다."),
+
     INVALID_STATUS(HttpStatus.BAD_REQUEST, "F-001", "진행 중, 완료된 필드에 대해서는 수정이 불가능합니다."),
 
     DELETE_FAILED(HttpStatus.BAD_REQUEST, "F-002", "완료된 필드에 대해서는 삭제가 불가능합니다."),

--- a/src/main/java/com/dnd/Exercise/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dnd/Exercise/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,29 @@
+package com.dnd.Exercise.global.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = jwtTokenProvider.resolveToken(request);
+
+        if (token != null && jwtTokenProvider.validateToken(token)) {
+            Authentication authentication = jwtTokenProvider.getAuthentication(token);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request,response);
+    }
+}

--- a/src/main/java/com/dnd/Exercise/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dnd/Exercise/global/jwt/JwtAuthenticationFilter.java
@@ -17,7 +17,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        String token = jwtTokenProvider.resolveToken(request);
+        String token = jwtTokenProvider.resolveAccessToken(request);
 
         if (token != null && jwtTokenProvider.validateToken(token)) {
             Authentication authentication = jwtTokenProvider.getAuthentication(token);

--- a/src/main/java/com/dnd/Exercise/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dnd/Exercise/global/jwt/JwtTokenProvider.java
@@ -1,6 +1,6 @@
 package com.dnd.Exercise.global.jwt;
 
-import com.dnd.Exercise.domain.auth.repository.RefreshTokenRepository;
+import com.dnd.Exercise.domain.auth.repository.RefreshTokenRedisRepository;
 import com.dnd.Exercise.domain.auth.service.CustomUserDetailsService;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +31,7 @@ public class JwtTokenProvider {
     private long refreshTokenValidTime;
 
     private final CustomUserDetailsService userDetailsService;
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 
     @PostConstruct
     protected void init() {
@@ -61,7 +61,7 @@ public class JwtTokenProvider {
                 .signWith(SignatureAlgorithm.HS256, secretKey)
                 .compact();
         RefreshToken refreshToken = new RefreshToken(token, id);
-        refreshTokenRepository.save(refreshToken);
+        refreshTokenRedisRepository.save(refreshToken);
         return refreshToken.getRefreshToken();
     }
 

--- a/src/main/java/com/dnd/Exercise/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dnd/Exercise/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,86 @@
+package com.dnd.Exercise.global.jwt;
+
+import com.dnd.Exercise.domain.auth.service.CustomUserDetailsService;
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.authority.AuthorityUtils;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.http.HttpServletRequest;
+import java.util.Base64;
+import java.util.Date;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class JwtTokenProvider {
+
+    // TODO: refresh 토큰 발급 추가
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.access-token-valid-minute}")
+    private long tokenValidTime;
+
+    private final CustomUserDetailsService userDetailsService;
+
+    @PostConstruct
+    protected void init() {
+        secretKey = Base64.getEncoder().encodeToString(secretKey.getBytes());
+        tokenValidTime = tokenValidTime * 60 * 1000L;
+    }
+
+    public String createToken(String uid) {
+        Claims claims = Jwts.claims().setSubject(uid);
+        Date now = new Date();
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + tokenValidTime))
+                .signWith(SignatureAlgorithm.HS256, secretKey)
+                .compact();
+    }
+
+    public Authentication getAuthentication(String token) {
+        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserUid(token));
+        return new UsernamePasswordAuthenticationToken(userDetails.getUsername(), null, AuthorityUtils.NO_AUTHORITIES);
+    }
+
+    public String getUserUid(String token) {
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String authorization = request.getHeader("Authorization");
+        if (authorization == null) {
+            return null;
+        }
+        return authorization.substring("Bearer ".length());
+    }
+
+    public boolean validateToken(String jwtToken) {
+        try {
+            Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(jwtToken);
+            return !claims.getBody().getExpiration().before(new Date());
+        } catch (SignatureException | MalformedJwtException e) {
+            log.info("JWT 토큰이 유효하지 않습니다.");
+            // TODO: 예외처리
+        } catch (ExpiredJwtException e) {
+            log.info("JWT 토큰이 만료되었습니다.");
+            // TODO: 예외처리
+        } catch (UnsupportedJwtException e) {
+            log.info("지원하지 않는 JWT 토큰입니다.");
+            // TODO: 예외처리
+        } catch (IllegalArgumentException e) {
+            log.info("JWT 토큰이 잘못되었습니다.");
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/dnd/Exercise/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dnd/Exercise/global/jwt/JwtTokenProvider.java
@@ -37,8 +37,8 @@ public class JwtTokenProvider {
         tokenValidTime = tokenValidTime * 60 * 1000L;
     }
 
-    public String createToken(String uid) {
-        Claims claims = Jwts.claims().setSubject(uid);
+    public String createToken(Long id) {
+        Claims claims = Jwts.claims().setSubject(id.toString());
         Date now = new Date();
         return Jwts.builder()
                 .setClaims(claims)
@@ -49,11 +49,11 @@ public class JwtTokenProvider {
     }
 
     public Authentication getAuthentication(String token) {
-        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserUid(token));
-        return new UsernamePasswordAuthenticationToken(userDetails.getUsername(), null, AuthorityUtils.NO_AUTHORITIES);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserId(token));
+        return new UsernamePasswordAuthenticationToken(Long.parseLong(userDetails.getUsername()), null, AuthorityUtils.NO_AUTHORITIES);
     }
 
-    public String getUserUid(String token) {
+    public String getUserId(String token) {
         return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
     }
 

--- a/src/main/java/com/dnd/Exercise/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dnd/Exercise/global/jwt/JwtTokenProvider.java
@@ -67,7 +67,7 @@ public class JwtTokenProvider {
 
     public Authentication getAuthentication(String token) {
         UserDetails userDetails = userDetailsService.loadUserByUsername(this.getUserId(token));
-        return new UsernamePasswordAuthenticationToken(Long.parseLong(userDetails.getUsername()), null, AuthorityUtils.NO_AUTHORITIES);
+        return new UsernamePasswordAuthenticationToken(userDetails, null, AuthorityUtils.NO_AUTHORITIES);
     }
 
     public String getUserId(String token) {

--- a/src/main/java/com/dnd/Exercise/global/jwt/RefreshToken.java
+++ b/src/main/java/com/dnd/Exercise/global/jwt/RefreshToken.java
@@ -3,12 +3,14 @@ package com.dnd.Exercise.global.jwt;
 import lombok.Getter;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.index.Indexed;
 
 @Getter
 @RedisHash(value = "refreshToken", timeToLive = 7 * 24 * 60 * 60 * 1000L)
 public class RefreshToken {
     @Id
     private String refreshToken;
+    @Indexed
     private Long userId;
 
     public RefreshToken(final String refreshToken, final Long userId) {

--- a/src/main/java/com/dnd/Exercise/global/jwt/RefreshToken.java
+++ b/src/main/java/com/dnd/Exercise/global/jwt/RefreshToken.java
@@ -1,0 +1,18 @@
+package com.dnd.Exercise.global.jwt;
+
+import lombok.Getter;
+import org.springframework.data.redis.core.RedisHash;
+import org.springframework.data.annotation.Id;
+
+@Getter
+@RedisHash(value = "refreshToken", timeToLive = 7 * 24 * 60 * 60 * 1000L)
+public class RefreshToken {
+    @Id
+    private String refreshToken;
+    private Long userId;
+
+    public RefreshToken(final String refreshToken, final Long userId) {
+        this.refreshToken = refreshToken;
+        this.userId = userId;
+    }
+}


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- 기초 회원가입, 로그인 기능을 구현합니다. 
    - 전화번호 인증, 소셜로그인, 아이디/비번 찾기 제외

## 📋 변경 사항
- `회원가입 API` 
- `로그인 API` 
- `회원가입 시 중복 id 체크 API` 
- `access 토큰 만료 시 재발급 API` 
- `로그아웃 API` 

## 🔍 Code Review

## 📸 ScreenShot

## 연결된 이슈 Close
close #31
