### PR TITLE
Feat: User API 구현

### DIFF
--- a/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/auth/service/AuthServiceImpl.java
@@ -40,6 +40,7 @@ public class AuthServiceImpl implements AuthService {
                 .skillLevel(signUpReq.getSkillLevel())
                 .loginType(LoginType.MATCH_UP)
                 .isAppleLinked(false)
+                .isNotificationAgreed(true)
                 .build());
     }
 

--- a/src/main/java/com/dnd/Exercise/domain/user/controller/UserController.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/controller/UserController.java
@@ -2,16 +2,27 @@ package com.dnd.Exercise.domain.user.controller;
 
 import com.dnd.Exercise.domain.user.dto.request.*;
 import com.dnd.Exercise.domain.user.dto.response.GetProfileDetail;
+import com.dnd.Exercise.domain.user.entity.User;
+import com.dnd.Exercise.domain.user.service.UserService;
 import com.dnd.Exercise.global.common.ResponseDto;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
 
 @Api(tags = "사용자 👤")
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/users")
 public class UserController {
+
+    private final UserService userService;
 
     @ApiOperation(value = "test")
     @PostMapping("/{id}")
@@ -25,39 +36,64 @@ public class UserController {
 
     @ApiOperation(value = "내 정보 상세 조회 👤", notes = "'마이페이지' 사용")
     @GetMapping("/my/profile-detail")
-    public ResponseEntity<GetProfileDetail> getProfileDetail() {
-        return ResponseDto.ok(new GetProfileDetail());
+    public ResponseEntity<GetProfileDetail> getProfileDetail(@AuthenticationPrincipal User user) {
+        GetProfileDetail getProfileDetail = userService.getProfileDetail(user.getId());
+        return ResponseDto.ok(getProfileDetail);
     }
 
-    @ApiOperation(value = "온보딩 시 내 정보 업데이트 👤", notes = "[ 신체정보(몸무게,키) / 목표칼로리 / 성별 / 애플 연동 여부 / (연동유저일 경우) 목표칼로리 ] 정보를 입력합니다. <br> '애플 초기 연동' or '연동 안한 유저의 온보딩' 에서 사용합니다.")
+    @ApiOperation(value = "온보딩 시 내 정보(신체정보) 등록 👤", notes = "[ 신체정보(몸무게,키) / 성별 / 애플 연동 여부 / (연동유저일 경우) 목표칼로리 ] 정보를 입력합니다. " +
+            "<br> '애플 데이터와의 초기 연동' or '연동 안한 유저의 온보딩' 에서 사용합니다.")
+    @ApiResponses({
+            @ApiResponse(code=200, message="온보딩 정보 업데이트 완료"),
+            @ApiResponse(code=400, message="애플 연동을 수행한 유저만 목표 칼로리를 설정할 수 있습니다."),
+            @ApiResponse(code=400, message="애플 연동 유저인 경우 목표 칼로리 값을 전송해야 합니다.")
+    })
     @PatchMapping("/my/onboard-profile")
-    public ResponseEntity<String> updateOnboardProfile(@RequestBody UpdateOnboardProfileReq updateOnboardProfileReq) {
+    public ResponseEntity<String> updateOnboardProfile(@RequestBody @Valid UpdateOnboardProfileReq updateOnboardProfileReq, @AuthenticationPrincipal User user) {
+        userService.updateOnboardProfile(updateOnboardProfileReq,user.getId());
         return ResponseDto.ok("온보딩 정보 업데이트 완료");
     }
 
-    @ApiOperation(value = "온보딩 시 운동레벨 등록 👤", notes = "[ 일반로그인의 경우 ] 회원가입을 진행하며 운동레벨을 함께 등록하므로, 이 api 를 사용하지 않습니다. <br> [ 소셜로그인의 경우 ] 소셜 회원가입 마친 뒤, 이 api 를 사용해 운동레벨을 추가로 등록합니다.")
+    @ApiOperation(value = "온보딩 시 운동레벨 등록 👤", notes = "[ 일반로그인의 경우 ] 회원가입을 진행하며 운동레벨을 함께 등록하므로, 일반로그인 과정에서는 이 api 를 사용하지 않습니다. " +
+            "<br> [ 소셜로그인의 경우 ] 소셜 회원가입 과정을 마친 뒤, 이 api 를 사용해 운동레벨을 추가로 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(code=200, message="운동레벨 등록 완료")
+    })
     @PostMapping("/my/skill-level")
-    public ResponseEntity<String> postSkillLevel(@RequestBody PostSkillLevelReq postSkillLevelReq) {
+    public ResponseEntity<String> postSkillLevel(@RequestBody @Valid PostSkillLevelReq postSkillLevelReq, @AuthenticationPrincipal User user) {
+        userService.postSkillLevel(postSkillLevelReq,user.getId());
         return ResponseDto.ok("운동레벨 등록 완료");
     }
 
     @ApiOperation(value = "내 프로필 수정 👤", notes = "'마이페이지' 사용 <br> 목표 칼로리는 수정할 수 없다.")
-    @PatchMapping("/my/profile")
-    public ResponseEntity<String> updateProfile(@RequestBody UpdateMyProfileReq updateMyProfileReq) {
+    @ApiResponses({
+            @ApiResponse(code=200, message="프로필 수정 완료")
+    })
+    @PostMapping("/my/profile")
+    public ResponseEntity<String> updateProfile(@ModelAttribute @Valid UpdateMyProfileReq updateMyProfileReq, @AuthenticationPrincipal User user) {
+        userService.updateProfile(updateMyProfileReq,user.getId());
         return ResponseDto.ok("프로필 수정 완료");
     }
 
     @ApiOperation(value = "애플 연동 여부 수정 👤", notes = "애플 연동 설정/해제 시 '연동 여부 정보' 업데이트 " +
             "<br> - 초기 회원가입 시 서버에 '유저의 애플 연동 여부' 는 기본적으로 false 로 설정됩니다." +
             "<br> - 추후 유저가 애플 연동을 수행하거나, 되어있던 연동을 해제할 시 서버로 '연동 여부' 정보를 업데이트합니다.")
+    @ApiResponses({
+            @ApiResponse(code=200, message="연동 정보 수정 완료")
+    })
     @PatchMapping("/my/apple-linked")
-    public ResponseEntity<String> updateAppleLinked(@RequestBody UpdateAppleLinkedReq updateAppleLinkedReq) {
+    public ResponseEntity<String> updateAppleLinked(@RequestBody @Valid UpdateAppleLinkedReq updateAppleLinkedReq, @AuthenticationPrincipal User user) {
+        userService.updateAppleLinked(updateAppleLinkedReq, user.getId());
         return ResponseDto.ok("연동 정보 수정 완료");
     }
 
-    @ApiOperation(value = "알림 수신 여부 수정 👤", notes = "푸시알림 수신 여부를 설정합니다.")
+    @ApiOperation(value = "알림 수신 여부 수정 👤", notes = "푸시알림 수신 여부를 설정합니다. 기본값은 true 로 설정되어 있습니다.")
+    @ApiResponses({
+            @ApiResponse(code=200, message="알림 수신여부 수정 완료")
+    })
     @PatchMapping("/my/notification-agreement")
-    public ResponseEntity<String> updateNotificationAgreement(@RequestBody UpdateNotificationAgreementReq updateNotificationAgreementReq) {
+    public ResponseEntity<String> updateNotificationAgreement(@RequestBody @Valid UpdateNotificationAgreementReq updateNotificationAgreementReq, @AuthenticationPrincipal User user) {
+        userService.updateNotificationAgreed(updateNotificationAgreementReq, user.getId());
         return ResponseDto.ok("알림 수신여부 수정 완료");
     }
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/UserMapper.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/UserMapper.java
@@ -1,0 +1,22 @@
+package com.dnd.Exercise.domain.user.dto;
+
+import com.dnd.Exercise.domain.user.dto.request.UpdateMyProfileReq;
+import com.dnd.Exercise.domain.user.dto.request.UpdateOnboardProfileReq;
+import com.dnd.Exercise.domain.user.dto.response.GetProfileDetail;
+import com.dnd.Exercise.domain.user.entity.User;
+import org.mapstruct.*;
+
+import static org.mapstruct.NullValuePropertyMappingStrategy.IGNORE;
+
+@Mapper(componentModel = "spring")
+public interface UserMapper {
+    GetProfileDetail from(User user);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = IGNORE,
+            unmappedTargetPolicy = ReportingPolicy.IGNORE)
+    void updateFromDto(UpdateOnboardProfileReq updateOnboardProfileReq, @MappingTarget User user);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = IGNORE,
+            unmappedTargetPolicy = ReportingPolicy.IGNORE)
+    void updateFromDto(UpdateMyProfileReq updateMyProfileReq, @MappingTarget User user);
+}

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/request/PostSkillLevelReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/request/PostSkillLevelReq.java
@@ -4,8 +4,11 @@ import com.dnd.Exercise.domain.field.entity.enums.SkillLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
+
 @Getter
 @NoArgsConstructor
 public class PostSkillLevelReq {
+    @NotNull
     private SkillLevel skillLevel;
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateAppleLinkedReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateAppleLinkedReq.java
@@ -1,11 +1,13 @@
 package com.dnd.Exercise.domain.user.dto.request;
 
-import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
 
 @Getter
 @NoArgsConstructor
 public class UpdateAppleLinkedReq {
+    @NotNull
     private Boolean isAppleLinked;
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateMyProfileReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateMyProfileReq.java
@@ -24,9 +24,9 @@ public class UpdateMyProfileReq {
 
     private Integer age;
 
-    private Integer height;
+    private Double height;
 
-    private Integer weight;
+    private Double weight;
 
     private SkillLevel skillLevel;
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateMyProfileReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateMyProfileReq.java
@@ -1,21 +1,32 @@
 package com.dnd.Exercise.domain.user.dto.request;
 
 import com.dnd.Exercise.domain.field.entity.enums.SkillLevel;
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+import javax.validation.constraints.NotNull;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class UpdateMyProfileReq {
     private String name;
 
-    private String profileImg;
+    @NotNull
+    @ApiModelProperty(value = "기존 프로필 이미지 삭제 여부 (유저가 이미지 카드 UI의 x표시를 클릭해 기존 이미지 제거 시 true 로 설정. 디폴트값은 false)")
+    private Boolean deletePrevImg;
 
-    private int age;
+    @ApiModelProperty(value = "새로 업로드 하고자 하는 프로필 이미지")
+    private MultipartFile newProfileImg;
 
-    private int height;
+    private Integer age;
 
-    private int weight;
+    private Integer height;
+
+    private Integer weight;
 
     private SkillLevel skillLevel;
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateNotificationAgreementReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateNotificationAgreementReq.java
@@ -3,8 +3,11 @@ package com.dnd.Exercise.domain.user.dto.request;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
+
 @Getter
 @NoArgsConstructor
 public class UpdateNotificationAgreementReq {
+    @NotNull
     private Boolean isNotificationAgreed;
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateOnboardProfileReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateOnboardProfileReq.java
@@ -10,10 +10,10 @@ import javax.validation.constraints.NotNull;
 @NoArgsConstructor
 public class UpdateOnboardProfileReq {
     @NotNull
-    private int weight;
+    private double weight;
 
     @NotNull
-    private int height;
+    private double height;
 
     @NotNull
     private Gender gender;

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateOnboardProfileReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/request/UpdateOnboardProfileReq.java
@@ -4,16 +4,22 @@ import com.dnd.Exercise.domain.user.entity.Gender;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
+
 @Getter
 @NoArgsConstructor
 public class UpdateOnboardProfileReq {
+    @NotNull
     private int weight;
 
+    @NotNull
     private int height;
 
+    @NotNull
     private Gender gender;
 
+    @NotNull
     private Boolean isAppleLinked;
 
-    private int calorieGoal;
+    private Integer calorieGoal;
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/response/GetProfileDetail.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/response/GetProfileDetail.java
@@ -5,11 +5,13 @@ import com.dnd.Exercise.domain.user.entity.Gender;
 import com.dnd.Exercise.domain.user.entity.LoginType;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 
 @Getter
+@Setter
 @NoArgsConstructor
 public class GetProfileDetail {
     private String uid;

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/response/GetProfileDetail.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/response/GetProfileDetail.java
@@ -26,8 +26,8 @@ public class GetProfileDetail {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
-    private int height;
-    private int weight;
+    private double height;
+    private double weight;
 
     @Enumerated(EnumType.STRING)
     private SkillLevel skillLevel;

--- a/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
@@ -44,9 +44,9 @@ public class User extends BaseEntity implements UserDetails {
     @Enumerated(EnumType.STRING)
     private Gender gender;
 
-    private int height;
+    private double height;
 
-    private int weight;
+    private double weight;
 
     @Enumerated(EnumType.STRING)
     private SkillLevel skillLevel;

--- a/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
@@ -16,6 +16,7 @@ import java.util.HashSet;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity implements UserDetails {
     @Id
@@ -98,7 +99,7 @@ public class User extends BaseEntity implements UserDetails {
     }
 
     @Builder
-    public User(String uid, String password, String phoneNum, String name, SkillLevel skillLevel, LoginType loginType, Boolean isAppleLinked) {
+    public User(String uid, String password, String phoneNum, String name, SkillLevel skillLevel, LoginType loginType, Boolean isAppleLinked, Boolean isNotificationAgreed) {
         this.uid = uid;
         this.password = password;
         this.phoneNum = phoneNum;
@@ -106,10 +107,27 @@ public class User extends BaseEntity implements UserDetails {
         this.skillLevel = skillLevel;
         this.loginType = loginType;
         this.isAppleLinked = isAppleLinked;
+        this.isNotificationAgreed = isNotificationAgreed;
     }
 
     public void addToken(FcmToken fcmToken) {
         fcmTokens.add(fcmToken);
         fcmToken.addUser(this);
+    }
+
+    public void updateSkillLevel(SkillLevel skillLevel) {
+        this.skillLevel = skillLevel;
+    }
+
+    public void updateProfileImgUrl(String imgUrl) {
+        this.profileImg = imgUrl;
+    }
+
+    public void updateIsAppleLinked(Boolean isAppleLinked) {
+        this.isAppleLinked = isAppleLinked;
+    }
+
+    public void updateIsNotificationAgreed(Boolean isNotificationAgreed) {
+        this.isNotificationAgreed = isNotificationAgreed;
     }
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/service/UserService.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/service/UserService.java
@@ -1,0 +1,13 @@
+package com.dnd.Exercise.domain.user.service;
+
+import com.dnd.Exercise.domain.user.dto.request.*;
+import com.dnd.Exercise.domain.user.dto.response.GetProfileDetail;
+
+public interface UserService {
+    GetProfileDetail getProfileDetail(long userId);
+    void updateOnboardProfile(UpdateOnboardProfileReq updateOnboardProfileReq, long userId);
+    void postSkillLevel(PostSkillLevelReq postSkillLevelReq, long userId);
+    void updateProfile(UpdateMyProfileReq updateMyProfileReq, long userId);
+    void updateAppleLinked(UpdateAppleLinkedReq updateAppleLinkedReq, long userId);
+    void updateNotificationAgreed(UpdateNotificationAgreementReq updateNotificationAgreementReq, long userId);
+}

--- a/src/main/java/com/dnd/Exercise/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,111 @@
+package com.dnd.Exercise.domain.user.service;
+
+import com.dnd.Exercise.domain.user.dto.UserMapper;
+import com.dnd.Exercise.domain.user.dto.request.*;
+import com.dnd.Exercise.domain.user.dto.response.GetProfileDetail;
+import com.dnd.Exercise.domain.user.entity.User;
+import com.dnd.Exercise.domain.user.repository.UserRepository;
+import com.dnd.Exercise.global.error.dto.ErrorCode;
+import com.dnd.Exercise.global.error.exception.BusinessException;
+import com.dnd.Exercise.global.s3.AwsS3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    private final UserMapper userMapper;
+
+    private final AwsS3Service awsS3Service;
+    private final String S3_FOLDER = "user-profile";
+
+    @Override
+    public GetProfileDetail getProfileDetail(long userId) {
+        User user = getUser(userId);
+        return userMapper.from(user);
+    }
+
+    @Override
+    @Transactional
+    public void updateOnboardProfile(UpdateOnboardProfileReq updateOnboardProfileReq, long userId) {
+        validateCalorieGoal(updateOnboardProfileReq);
+        User user = getUser(userId);
+        userMapper.updateFromDto(updateOnboardProfileReq,user);
+    }
+
+    @Override
+    @Transactional
+    public void postSkillLevel(PostSkillLevelReq postSkillLevelReq, long userId) {
+        User user = getUser(userId);
+        user.updateSkillLevel(postSkillLevelReq.getSkillLevel());
+    }
+
+    @Override
+    @Transactional
+    public void updateProfile(UpdateMyProfileReq updateMyProfileReq, long userId) {
+        User user = getUser(userId);
+
+        if (updateMyProfileReq.getDeletePrevImg() == true) {
+            deleteMemoImgAtS3(user.getProfileImg());
+            user.updateProfileImgUrl(null);
+        }
+
+        if (updateMyProfileReq.getNewProfileImg() != null) {
+            String newImgUrl = postMemoImgAtS3(updateMyProfileReq.getNewProfileImg());
+            user.updateProfileImgUrl(newImgUrl);
+        }
+
+        userMapper.updateFromDto(updateMyProfileReq,user);
+    }
+
+    @Override
+    @Transactional
+    public void updateAppleLinked(UpdateAppleLinkedReq updateAppleLinkedReq, long userId) {
+        User user = getUser(userId);
+        user.updateIsAppleLinked(updateAppleLinkedReq.getIsAppleLinked());
+    }
+
+    @Override
+    @Transactional
+    public void updateNotificationAgreed(UpdateNotificationAgreementReq updateNotificationAgreementReq, long userId) {
+        User user = getUser(userId);
+        user.updateIsNotificationAgreed(updateNotificationAgreementReq.getIsNotificationAgreed());
+    }
+
+    private User getUser(long userId) {
+        return userRepository.findById(userId).get();
+    }
+
+    private void validateCalorieGoal(UpdateOnboardProfileReq updateOnboardProfileReq) {
+        if (updateOnboardProfileReq.getIsAppleLinked() == true) {
+            if (updateOnboardProfileReq.getCalorieGoal() == null) {
+                throw new BusinessException(ErrorCode.NEED_CALORIE_GOAL);
+            }
+        }
+        else {
+            if (updateOnboardProfileReq.getCalorieGoal() != null) {
+                throw new BusinessException(ErrorCode.CALORIE_GOAL_UPDATE_UNAVAILABLE);
+            }
+        }
+    }
+
+    private String postMemoImgAtS3(MultipartFile memoImg) {
+        String imgUrl = null;
+        if (memoImg != null) {
+            imgUrl = awsS3Service.upload(memoImg,S3_FOLDER);
+        }
+        return imgUrl;
+    }
+
+    private void deleteMemoImgAtS3(String fileName) {
+        if(fileName != null) {
+            awsS3Service.deleteImage(fileName);
+        }
+    }
+}

--- a/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
+++ b/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
@@ -73,6 +73,10 @@ public enum ErrorCode {
 
     APPLE_WORKOUTS_UPDATE_UNAVAILABLE(HttpStatus.BAD_REQUEST, "E-003", "애플 연동을 수행한 유저만 애플 운동기록을 업로드 할 수 있습니다."),
 
+    CALORIE_GOAL_UPDATE_UNAVAILABLE(HttpStatus.BAD_REQUEST, "U-001", "애플 연동을 수행한 유저만 목표 칼로리를 설정할 수 있습니다."),
+
+    NEED_CALORIE_GOAL(HttpStatus.BAD_REQUEST, "U-002", "애플 연동 유저인 경우 목표 칼로리 값을 전송해야 합니다."),
+
     UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "S-001", "업로드 중 오류가 발생했습니다."),
 
     FILE_DELETE_FAILED(HttpStatus.BAD_REQUEST, "S-002", "파일 삭제 중 오류가 발생했습니다."),

--- a/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
+++ b/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
@@ -71,7 +71,7 @@ public enum ErrorCode {
 
     NEED_USER_WEIGHT_FOR_EXPECTED_CALORIE(HttpStatus.BAD_REQUEST,"E-002","예상 소모 칼로리 계산을 위해서는 몸무게가 사전 입력되어야 합니다."),
 
-    APPLE_WORKOUTS_UPDATE_UNAVAILABLE(HttpStatus.BAD_REQUEST, "E-002", "애플 연동을 수행한 유저만 애플 운동기록을 업로드 할 수 있습니다."),
+    APPLE_WORKOUTS_UPDATE_UNAVAILABLE(HttpStatus.BAD_REQUEST, "E-003", "애플 연동을 수행한 유저만 애플 운동기록을 업로드 할 수 있습니다."),
 
     UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "S-001", "업로드 중 오류가 발생했습니다."),
 


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- UserController 의 API 들을 구현합니다.

## 📋 변경 사항
- 유저 키,몸무게 `int` -> `double` 형으로 변경
- `getProfileDetail`
- `updateOnboardProfile`
- `postSkillLevel`
- `updateProfile`
- `updateAppleLinked`
- `updateNotificationAgreement`

## 🔍 Code Review

## 📸 ScreenShot

## 연결된 이슈 Close
close #68 
