### PR TITLE
Feat: 전화번호 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,6 +63,9 @@ dependencies {
 
 	// firebase
 	implementation 'com.google.firebase:firebase-admin:7.1.0'
+
+	// http client
+	implementation group: 'org.apache.httpcomponents', name: 'httpclient', version: '4.5.13'
 }
 
 jar {

--- a/src/main/java/com/dnd/Exercise/domain/verification/controller/VerificationController.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/controller/VerificationController.java
@@ -38,7 +38,8 @@ public class VerificationController {
 
     @ApiOperation(value = "인증번호 인증 📞", notes = "발송받은 인증번호로 인증을 수행합니다. 인증 성공 여부를 반환합니다.")
     @PostMapping("/verify")
-    public ResponseEntity<Boolean> verify(@RequestBody VerifyReq verifyReq) {
-        return ResponseDto.ok(false);
+    public ResponseEntity<String> verify(@RequestBody @Valid VerifyReq verifyReq) {
+        verificationService.verify(verifyReq);
+        return ResponseDto.ok("인증되었습니다.");
     }
 }

--- a/src/main/java/com/dnd/Exercise/domain/verification/controller/VerificationController.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/controller/VerificationController.java
@@ -6,6 +6,8 @@ import com.dnd.Exercise.domain.verification.service.VerificationService;
 import com.dnd.Exercise.global.common.ResponseDto;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +28,9 @@ public class VerificationController {
     private final VerificationService verificationService;
 
     @ApiOperation(value = "인증번호 전송 요청 📞", notes = "해당 전화번호로 인증번호를 발송합니다.")
+    @ApiResponses({
+            @ApiResponse(code=200, message="인증번호 발송 완료")
+    })
     @PostMapping("/send-code")
     public ResponseEntity<String> sendCode(@RequestBody @Valid SendCodeReq sendCodeReq) {
         try {
@@ -36,7 +41,11 @@ public class VerificationController {
         return ResponseDto.ok("인증번호 발송 완료");
     }
 
-    @ApiOperation(value = "인증번호 인증 📞", notes = "발송받은 인증번호로 인증을 수행합니다. 인증 성공 여부를 반환합니다.")
+    @ApiOperation(value = "인증번호 인증 📞", notes = "발송받은 인증번호로 인증을 수행합니다.")
+    @ApiResponses({
+            @ApiResponse(code=200, message="인증되었습니다."),
+            @ApiResponse(code=400, message="잘못된 인증번호입니다. or 인증번호 유효시간이 지났습니다.")
+    })
     @PostMapping("/verify")
     public ResponseEntity<String> verify(@RequestBody @Valid VerifyReq verifyReq) {
         verificationService.verify(verifyReq);

--- a/src/main/java/com/dnd/Exercise/domain/verification/controller/VerificationController.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/controller/VerificationController.java
@@ -2,23 +2,37 @@ package com.dnd.Exercise.domain.verification.controller;
 
 import com.dnd.Exercise.domain.verification.dto.request.SendCodeReq;
 import com.dnd.Exercise.domain.verification.dto.request.VerifyReq;
+import com.dnd.Exercise.domain.verification.service.VerificationService;
 import com.dnd.Exercise.global.common.ResponseDto;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.validation.Valid;
+
 @Api(tags = "전화번호 인증 📞")
+@Slf4j
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/verification")
 public class VerificationController {
 
+    private final VerificationService verificationService;
+
     @ApiOperation(value = "인증번호 전송 요청 📞", notes = "해당 전화번호로 인증번호를 발송합니다.")
     @PostMapping("/send-code")
-    public ResponseEntity<String> sendCode(@RequestBody SendCodeReq sendCodeReq) {
+    public ResponseEntity<String> sendCode(@RequestBody @Valid SendCodeReq sendCodeReq) {
+        try {
+            verificationService.sendSms(sendCodeReq);
+        } catch (Exception e) {
+            log.error("error while sending verification code: {}", e);
+        }
         return ResponseDto.ok("인증번호 발송 완료");
     }
 

--- a/src/main/java/com/dnd/Exercise/domain/verification/dto/request/MessageDto.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/dto/request/MessageDto.java
@@ -1,0 +1,13 @@
+package com.dnd.Exercise.domain.verification.dto.request;
+
+import lombok.*;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+@Builder
+public class MessageDto {
+    String to;
+    String content;
+}

--- a/src/main/java/com/dnd/Exercise/domain/verification/dto/request/NaverSmsReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/dto/request/NaverSmsReq.java
@@ -1,0 +1,19 @@
+package com.dnd.Exercise.domain.verification.dto.request;
+
+import lombok.*;
+
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+@Builder
+public class NaverSmsReq {
+    String type;
+    String contentType;
+    String countryCode;
+    String from;
+    String content;
+    List<MessageDto> messages;
+}

--- a/src/main/java/com/dnd/Exercise/domain/verification/dto/request/SendCodeReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/dto/request/SendCodeReq.java
@@ -1,13 +1,17 @@
 package com.dnd.Exercise.domain.verification.dto.request;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 
 @Getter
 @NoArgsConstructor
 public class SendCodeReq {
+    @ApiModelProperty(value = "10~11 자리 숫자의 휴대폰번호", required = true, example = "01012345678")
     @NotBlank
+    @Pattern(regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$", message = "휴대폰 번호는 10~11자리의 숫자로만 입력 가능합니다.")
     private String phoneNum;
 }

--- a/src/main/java/com/dnd/Exercise/domain/verification/dto/request/SendCodeReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/dto/request/SendCodeReq.java
@@ -3,8 +3,11 @@ package com.dnd.Exercise.domain.verification.dto.request;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+
 @Getter
 @NoArgsConstructor
 public class SendCodeReq {
+    @NotBlank
     private String phoneNum;
 }

--- a/src/main/java/com/dnd/Exercise/domain/verification/dto/request/VerifyReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/dto/request/VerifyReq.java
@@ -1,16 +1,22 @@
 package com.dnd.Exercise.domain.verification.dto.request;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 
 @Getter
 @NoArgsConstructor
 public class VerifyReq {
+    @ApiModelProperty(value = "10~11 자리 숫자의 휴대폰번호", required = true, example = "01012345678")
     @NotBlank
+    @Pattern(regexp = "^01(?:0|1|[6-9])(?:\\d{3}|\\d{4})\\d{4}$", message = "휴대폰 번호는 10~11자리의 숫자로만 입력 가능합니다.")
     private String phoneNum;
 
+    @ApiModelProperty(value = "6자리 숫자 인증번호", required = true, example = "001122")
     @NotBlank
+    @Pattern(regexp = "^\\d{6}$", message = "인증번호는 6자리의 숫자로만 입력 가능합니다.")
     private String code;
 }

--- a/src/main/java/com/dnd/Exercise/domain/verification/dto/request/VerifyReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/dto/request/VerifyReq.java
@@ -3,9 +3,14 @@ package com.dnd.Exercise.domain.verification.dto.request;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotBlank;
+
 @Getter
 @NoArgsConstructor
 public class VerifyReq {
+    @NotBlank
+    private String phoneNum;
 
+    @NotBlank
     private String code;
 }

--- a/src/main/java/com/dnd/Exercise/domain/verification/dto/response/NaverSmsRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/dto/response/NaverSmsRes.java
@@ -1,0 +1,17 @@
+package com.dnd.Exercise.domain.verification.dto.response;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Setter
+@Getter
+@Builder
+public class NaverSmsRes {
+    String requestId;
+    LocalDateTime requestTime;
+    String statusCode;
+    String statusName;
+}

--- a/src/main/java/com/dnd/Exercise/domain/verification/service/VerificationService.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/service/VerificationService.java
@@ -1,6 +1,7 @@
 package com.dnd.Exercise.domain.verification.service;
 
 import com.dnd.Exercise.domain.verification.dto.request.SendCodeReq;
+import com.dnd.Exercise.domain.verification.dto.request.VerifyReq;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.web.client.RestClientException;
 
@@ -11,4 +12,5 @@ import java.security.NoSuchAlgorithmException;
 
 public interface VerificationService {
     void sendSms(SendCodeReq sendCodeReq) throws JsonProcessingException, RestClientException, URISyntaxException, InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException;
+    void verify(VerifyReq verifyReq);
 }

--- a/src/main/java/com/dnd/Exercise/domain/verification/service/VerificationService.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/service/VerificationService.java
@@ -1,0 +1,14 @@
+package com.dnd.Exercise.domain.verification.service;
+
+import com.dnd.Exercise.domain.verification.dto.request.SendCodeReq;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.springframework.web.client.RestClientException;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+
+public interface VerificationService {
+    void sendSms(SendCodeReq sendCodeReq) throws JsonProcessingException, RestClientException, URISyntaxException, InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException;
+}

--- a/src/main/java/com/dnd/Exercise/domain/verification/service/VerificationServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/service/VerificationServiceImpl.java
@@ -40,6 +40,9 @@ import java.util.Random;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class VerificationServiceImpl implements VerificationService {
+    private static final int VERIFICATION_CODE_LENGTH = 6;
+    private static final long VERIFICATION_CODE_VALID_MINUTE = 10;
+
     @Value("${naver-cloud-sms.accessKey}")
     private String accessKey;
 
@@ -70,14 +73,14 @@ public class VerificationServiceImpl implements VerificationService {
         log.info("receiver phone number: {}", receiverPhone);
         log.info("verification code: {}", verificationCode);
 
-        redisService.setValues(receiverPhone, verificationCode, Duration.ofMinutes(10));
+        redisService.setValues(receiverPhone, verificationCode, Duration.ofMinutes(VERIFICATION_CODE_VALID_MINUTE));
 
         String messageContent = new StringBuilder()
                 .append("[매치업] ")
                 .append(verificationCode)
                 .append(" 인증번호를 입력해주세요.")
                 .append("\n")
-                .append("인증번호 유효시간은 10분입니다.")
+                .append("인증번호 유효시간은 " + VERIFICATION_CODE_VALID_MINUTE + "분입니다.")
                 .toString();
 
         List<MessageDto> messages = new ArrayList<>();
@@ -154,7 +157,7 @@ public class VerificationServiceImpl implements VerificationService {
     private String makeRandomNumber() {
         Random rand = new Random();
         String numStr = "";
-        for(int i=0; i<4; i++) {
+        for(int i=0; i<VERIFICATION_CODE_LENGTH; i++) {
             String num = Integer.toString(rand.nextInt(10));
             numStr += num;
         }

--- a/src/main/java/com/dnd/Exercise/domain/verification/service/VerificationServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/verification/service/VerificationServiceImpl.java
@@ -1,0 +1,120 @@
+package com.dnd.Exercise.domain.verification.service;
+
+import com.dnd.Exercise.domain.verification.dto.request.MessageDto;
+import com.dnd.Exercise.domain.verification.dto.request.NaverSmsReq;
+import com.dnd.Exercise.domain.verification.dto.request.SendCodeReq;
+import com.dnd.Exercise.domain.verification.dto.response.NaverSmsRes;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestClientException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.client.RestTemplate;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class VerificationServiceImpl implements VerificationService {
+    @Value("${naver-cloud-sms.accessKey}")
+    private String accessKey;
+
+    @Value("${naver-cloud-sms.secretKey}")
+    private String secretKey;
+
+    @Value("${naver-cloud-sms.serviceId}")
+    private String serviceId;
+
+    @Value("${naver-cloud-sms.senderPhone}")
+    private String senderPhone;
+
+    @Override
+    public void sendSms(SendCodeReq sendCodeReq) throws JsonProcessingException, RestClientException, URISyntaxException, InvalidKeyException, NoSuchAlgorithmException, UnsupportedEncodingException {
+        Long time = System.currentTimeMillis();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.set("x-ncp-apigw-timestamp", time.toString());
+        headers.set("x-ncp-iam-access-key", accessKey);
+        headers.set("x-ncp-apigw-signature-v2", makeSignature(time));
+
+        // TODO: 인증번호 난수생성
+        // TODO: redis 에 유효시간 설정하여 저장
+        String messageContent = new StringBuilder()
+                .append("[매치업] ")
+                .append("1234")
+                .append(" 인증번호를 입력해주세요.")
+                .append("\n")
+                .append("인증번호 유효시간은 10분입니다.")
+                .toString();
+
+        List<MessageDto> messages = new ArrayList<>();
+        messages.add(MessageDto.builder()
+                .to(sendCodeReq.getPhoneNum())
+                .content(messageContent)
+                .build());
+
+        NaverSmsReq request = NaverSmsReq.builder()
+                .type("SMS")
+                .contentType("COMM")
+                .countryCode("82")
+                .from(senderPhone)
+                .content(messageContent)
+                .messages(messages)
+                .build();
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        String jsonBody = objectMapper.writeValueAsString(request);
+        HttpEntity<String> httpBody = new HttpEntity<>(jsonBody, headers);
+
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setRequestFactory(new HttpComponentsClientHttpRequestFactory());
+
+        NaverSmsRes response = restTemplate.postForObject(new URI("https://sens.apigw.ntruss.com/sms/v2/services/"+ serviceId +"/messages"), httpBody, NaverSmsRes.class);
+    }
+
+    private String makeSignature(Long time) throws NoSuchAlgorithmException, UnsupportedEncodingException, InvalidKeyException {
+        String space = " ";
+        String newLine = "\n";
+        String method = "POST";
+        String url = "/sms/v2/services/" + this.serviceId + "/messages";
+        String timestamp = time.toString();
+        String accessKey = this.accessKey;
+        String secretKey = this.secretKey;
+
+        String message = new StringBuilder()
+                .append(method)
+                .append(space)
+                .append(url)
+                .append(newLine)
+                .append(timestamp)
+                .append(newLine)
+                .append(accessKey)
+                .toString();
+
+        SecretKeySpec signingKey = new SecretKeySpec(secretKey.getBytes("UTF-8"), "HmacSHA256");
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(signingKey);
+
+        byte[] rawHmac = mac.doFinal(message.getBytes("UTF-8"));
+        String encodeBase64String = Base64.getEncoder().encodeToString(rawHmac);
+
+        return encodeBase64String;
+    }
+}

--- a/src/main/java/com/dnd/Exercise/global/common/RedisService.java
+++ b/src/main/java/com/dnd/Exercise/global/common/RedisService.java
@@ -33,4 +33,7 @@ public class RedisService {
         redisTemplate.delete(key);
     }
 
+    public Boolean hasKey(String key) {
+        return redisTemplate.hasKey(key);
+    }
 }

--- a/src/main/java/com/dnd/Exercise/global/config/SecurityConfig.java
+++ b/src/main/java/com/dnd/Exercise/global/config/SecurityConfig.java
@@ -27,7 +27,8 @@ public class SecurityConfig {
             "/swagger-ui.html",
             "/webjars/**",
             /* apis */
-            "/auth/sign-up", "/auth/login", "/auth/id-available", "/auth/refresh"
+            "/auth/sign-up", "/auth/login", "/auth/id-available", "/auth/refresh",
+            "/verification/**"
     };
 
     private final JwtTokenProvider jwtTokenProvider;

--- a/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
+++ b/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
@@ -81,7 +81,11 @@ public enum ErrorCode {
 
     FILE_DELETE_FAILED(HttpStatus.BAD_REQUEST, "S-002", "파일 삭제 중 오류가 발생했습니다."),
 
-    FCM_TIME_LIMIT(HttpStatus.BAD_REQUEST, "N-001", "2시간마다 가능합니다.");
+    FCM_TIME_LIMIT(HttpStatus.BAD_REQUEST, "N-001", "2시간마다 가능합니다."),
+
+    INCORRECT_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "V-001", "잘못된 인증번호입니다."),
+
+    EXPIRED_VERIFICATION_CODE(HttpStatus.BAD_REQUEST, "V-002", "인증번호 유효시간이 지났습니다.");
 
     private final HttpStatus status;
     private final String code;


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
- naver sms api 를 활용한 인증코드 sms 전송을 구현합니다.
- 전화번호와 인증코드를 통한 유저 인증을 구현합니다.

## 📋 변경 사항
- `sendCode`
- `verify`

## 🔍 Code Review

## 📸 ScreenShot
![sms 인증코드 전송](https://github.com/dnd-side-project/dnd-9th-9-backend/assets/57743122/215bdfff-799a-4335-9ee9-fb894e091e26)

## 연결된 이슈 Close
close #72 
