### PR TITLE
Fix: 필드 신청 내역 삭제,  수락 및 팀원 내보내기 로직 수정 (#80)

### DIFF
--- a/src/main/java/com/dnd/Exercise/domain/fieldEntry/repository/FieldEntryRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/fieldEntry/repository/FieldEntryRepository.java
@@ -31,4 +31,8 @@ public interface FieldEntryRepository extends JpaRepository<FieldEntry, Long>, F
     Page<FieldEntry> findByEntrantField(Field field, Pageable pageable);
 
     void deleteAllByEntrantUserAndFieldType(User user, FieldType fieldType);
+
+    void deleteAllByHostFieldAndEntrantField(Field hostField, Field entrantField);
+
+    void deleteAllByHostFieldAndEntrantUser(Field hostField, User entrantUser);
 }

--- a/src/main/java/com/dnd/Exercise/domain/fieldEntry/service/FieldEntryServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/fieldEntry/service/FieldEntryServiceImpl.java
@@ -162,10 +162,14 @@ public class FieldEntryServiceImpl implements FieldEntryService {
             userFieldRepository.save(userField);
 
             fieldEntryRepository.deleteAllByEntrantUser(entrantUser);
+            if (hostField.getCurrentSize() == hostField.getMaxSize()){
+                fieldEntryRepository.deleteAllByHostFieldAndEntrantField(hostField, null);
+            }
         }
         else{
             entrantField.changeOpponent(hostField);
             fieldEntryRepository.deleteAllByEntrantField(entrantField);
+            fieldEntryRepository.deleteAllByHostFieldAndEntrantUser(hostField, null);
         }
     }
 

--- a/src/main/java/com/dnd/Exercise/domain/fieldEntry/service/FieldEntryServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/fieldEntry/service/FieldEntryServiceImpl.java
@@ -131,12 +131,12 @@ public class FieldEntryServiceImpl implements FieldEntryService {
 
         if(fieldEntry.getEntrantField() == null){
             if(!fieldEntry.getEntrantUser().equals(user)
-                    || !hostField.getLeaderId().equals(user.getId())){
+                    && !hostField.getLeaderId().equals(user.getId())){
                 throw new BusinessException(BAD_REQUEST);
             }
         }else{
             if(!entrantField.getLeaderId().equals(user.getId())
-                    || !hostField.getLeaderId().equals(user.getId())){
+                    && !hostField.getLeaderId().equals(user.getId())){
                 throw new BusinessException(FORBIDDEN);
             }
         }

--- a/src/main/java/com/dnd/Exercise/domain/userField/controller/UserFieldController.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/controller/UserFieldController.java
@@ -71,7 +71,8 @@ public class UserFieldController {
     @ApiResponses({
             @ApiResponse(code=200, message="팀원 내보내기 완료"),
             @ApiResponse(code=400, message="[F-008] 필드를 찾을 수 없습니다. "
-                    + "<br>[F-004] 매치가 이미 진행 중입니다."),
+                    + "<br>[F-004] 매치가 이미 진행 중입니다."
+                    + "<br>[C-000] 잘못된 요청"),
             @ApiResponse(code=403, message = "[F-009] 팀장 권한이 필요합니다.")
     })
     @DeleteMapping("/{id}/eject")

--- a/src/main/java/com/dnd/Exercise/domain/userField/repository/UserFieldRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/repository/UserFieldRepository.java
@@ -42,7 +42,7 @@ public interface UserFieldRepository extends JpaRepository<UserField, Long>, Use
              @Param("fieldTypes") List<FieldType> fieldTypes);
 
 
-    void deleteAllByFieldAndUserIn(Field field, List<User> targetUsers);
+    void deleteAllByFieldAndUserIdIn(Field field, List<Long> targetUserIds);
 
     void deleteByFieldAndUser(Field field, User user);
 }

--- a/src/main/java/com/dnd/Exercise/domain/userField/service/UserFieldServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/service/UserFieldServiceImpl.java
@@ -9,6 +9,7 @@ import static com.dnd.Exercise.domain.field.entity.enums.RankCriterion.RECORD_CO
 import static com.dnd.Exercise.global.common.Constants.REDIS_CHEER_PREFIX;
 import static com.dnd.Exercise.global.common.Constants.REDIS_NOTIFICATION_VERIFIED;
 import static com.dnd.Exercise.global.common.Constants.REDIS_WAKEUP_PREFIX;
+import static com.dnd.Exercise.global.error.dto.ErrorCode.BAD_REQUEST;
 import static com.dnd.Exercise.global.error.dto.ErrorCode.FCM_TIME_LIMIT;
 import static com.dnd.Exercise.global.error.dto.ErrorCode.MUST_NOT_LEADER;
 import static com.dnd.Exercise.global.error.dto.ErrorCode.NOT_FOUND;
@@ -35,7 +36,6 @@ import com.dnd.Exercise.domain.userField.dto.response.FindMyTeamStatusRes;
 import com.dnd.Exercise.domain.userField.dto.response.TopPlayerDto;
 import com.dnd.Exercise.domain.userField.entity.UserField;
 import com.dnd.Exercise.domain.userField.repository.UserFieldRepository;
-import com.dnd.Exercise.global.common.Constants;
 import com.dnd.Exercise.global.common.RedisService;
 import com.dnd.Exercise.global.error.exception.BusinessException;
 import com.dnd.Exercise.global.util.field.FieldUtil;
@@ -214,14 +214,16 @@ public class UserFieldServiceImpl implements UserFieldService {
         fieldUtil.validateIsLeader(user.getId(), field.getLeaderId());
         fieldUtil.validateHaveOpponent(field);
 
-        List<User> targetUsers = userRepository.findByIdIn(ids);
         List<Long> memberIds = fieldUtil.getMemberIds(fieldId);
 
-        if (targetUsers.stream().anyMatch(targetUser -> !memberIds.contains(targetUser.getId()))) {
+        if (ids.contains(user.getId())){
+            throw new BusinessException(BAD_REQUEST);
+        }
+        if (ids.stream().anyMatch(targetId -> !memberIds.contains(targetId))) {
             throw new BusinessException(NOT_MEMBER);
         }
 
-        userFieldRepository.deleteAllByFieldAndUserIn(field, targetUsers);
+        userFieldRepository.deleteAllByFieldAndUserIdIn(field, ids);
     }
 
     @Transactional


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
팀원 내보내기 시 방장이 본인을 내보낼 수 있는 문제 해결
필드 신청 내역 삭제 시 권한 문제 해결
필드 신청 수락에 따른 삭제 로직 추가

## 📋 변경 사항
- FieldEntry
    - deleteFieldEntry 예외 처리 추가
    - acceptFieldEntry 수락에 따른 삭제 로직 추가
        - 팀 신청 수락 시, 팀 인원이 가득찼을 경우 해당 필드로 들어온 모든 팀 신청내역 삭제 로직 추가
        - 배틀 신청 수락 시, 호스트필드로 들어온 모든 배틀 신청 삭제 로직 추가
- UserField
    - ejectMember 권한 로직 수정

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 연결된 이슈 Close
close #80
