### PR TITLE
Fix: 매칭 시작 시점 정책 통일 및 배틀 보유 여부 확인 API 추가, 에러 메시지 변경 (#85)

### DIFF
--- a/src/main/java/com/dnd/Exercise/domain/field/controller/FieldController.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/controller/FieldController.java
@@ -115,7 +115,7 @@ public class FieldController {
             @ApiResponse(code=403, message="[F-009] 팀장 권한이 필요합니다."),
             @ApiResponse(code=404, message="[F-008] 필드를 찾을 수 없습니다.")
     })
-    @PatchMapping("/{id}/profile")
+    @PostMapping("/{id}/profile")
     public ResponseEntity<String> updateFieldProfile(
             @AuthenticationPrincipal User user,
             @Parameter(description = "필드 Id값") @PathVariable("id") Long id,

--- a/src/main/java/com/dnd/Exercise/domain/field/controller/FieldController.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/controller/FieldController.java
@@ -58,8 +58,7 @@ public class FieldController {
     @ApiOperation(value = "필드 생성 🔥")
     @ApiResponses({
             @ApiResponse(code=200, message="필드 생성 완료"),
-            @ApiResponse(code=400, message="[FE-002] 이미 해당 유형의 필드를 가지고 있습니다. "
-                    + "가질 수 있는 최대 필드 수 : 1:1 배틀 1개, 팀 배틀 1개, 팀 1개 "
+            @ApiResponse(code=400, message="[FE-002] 이미 해당 유형의 매칭이 있습니다."
                     + "<br>[F-010] 1:1 배틀의 최대 인원은 1명입니다. ")
     })
     @PostMapping

--- a/src/main/java/com/dnd/Exercise/domain/field/service/FieldServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/service/FieldServiceImpl.java
@@ -257,7 +257,6 @@ public class FieldServiceImpl implements FieldService{
     public void updateFieldProfile(Long id, User user, UpdateFieldProfileReq updateFieldProfileReq) {
         Field field = fieldUtil.getField(id);
         fieldUtil.validateIsLeader(user.getId(), field.getLeaderId());
-        fieldUtil.validateHaveOpponent(field);
 
         if(field.getProfileImg() != null){
             awsS3Service.deleteImage(field.getProfileImg());

--- a/src/main/java/com/dnd/Exercise/domain/field/service/FieldServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/service/FieldServiceImpl.java
@@ -243,8 +243,8 @@ public class FieldServiceImpl implements FieldService{
 
         FindFieldRes.FindFieldResBuilder resBuilder = FindFieldRes.builder().fieldDto(fieldDto);
 
-        if (isMember && myField.getFieldStatus() == IN_PROGRESS){
-            Field opponentField = fieldUtil.getField(myField.getOpponent().getId());
+        Field opponentField = myField.getOpponent();
+        if (isMember && opponentField != null){
             FindAllFieldsDto assignedFieldDto = fieldMapper.toFindAllFieldsDto(opponentField);
             resBuilder.assignedFieldDto(assignedFieldDto);
         }

--- a/src/main/java/com/dnd/Exercise/domain/fieldEntry/controller/FieldEntryController.java
+++ b/src/main/java/com/dnd/Exercise/domain/fieldEntry/controller/FieldEntryController.java
@@ -89,7 +89,7 @@ public class FieldEntryController {
                     + "<br>[F-004] 매치가 이미 진행 중입니다. "
                     + "<br>[FE-003] 이미 팀원이 가득 찼습니다. "
                     + "<br>[FE-001] 이미 신청한 필드입니다. "
-                    + "<br>[FE-002] 이미 해당 유형의 필드를 가지고 있습니다. 가질 수 있는 최대 필드 수 : 1:1 배틀 1개, 팀 배틀 1개, 팀 1개")
+                    + "<br>[FE-002] 이미 해당 유형의 매칭이 있습니다.")
     })
     @PostMapping("/team")
     public ResponseEntity<String> createTeamFieldEntry(

--- a/src/main/java/com/dnd/Exercise/domain/fieldEntry/controller/FieldEntryController.java
+++ b/src/main/java/com/dnd/Exercise/domain/fieldEntry/controller/FieldEntryController.java
@@ -127,7 +127,7 @@ public class FieldEntryController {
             @ApiResponse(code=200, message="필드 신청 취소 완료"),
             @ApiResponse(code=400, message="[F-008] 필드를 찾을 수 없습니다."
                     + "<br>[C-000] 잘못된 요청"),
-            @ApiResponse(code=403, message = "[C-006] 접근 권한이 없습니다.")
+            @ApiResponse(code=403, message = "[FE-005] 매칭에 대한 설정은 팀장만 가능합니다.")
     })
     @DeleteMapping("/{id}")
     public ResponseEntity<String> deleteFieldEntry(

--- a/src/main/java/com/dnd/Exercise/domain/fieldEntry/service/FieldEntryServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/fieldEntry/service/FieldEntryServiceImpl.java
@@ -7,6 +7,7 @@ import static com.dnd.Exercise.global.error.dto.ErrorCode.ALREADY_FULL;
 import static com.dnd.Exercise.global.error.dto.ErrorCode.BAD_REQUEST;
 import static com.dnd.Exercise.global.error.dto.ErrorCode.FIELD_NOT_FOUND;
 import static com.dnd.Exercise.global.error.dto.ErrorCode.FORBIDDEN;
+import static com.dnd.Exercise.global.error.dto.ErrorCode.MUST_LEADER;
 import static com.dnd.Exercise.global.error.dto.ErrorCode.PERIOD_NOT_MATCH;
 
 import com.dnd.Exercise.domain.field.entity.Field;
@@ -137,7 +138,7 @@ public class FieldEntryServiceImpl implements FieldEntryService {
         }else{
             if(!entrantField.getLeaderId().equals(user.getId())
                     && !hostField.getLeaderId().equals(user.getId())){
-                throw new BusinessException(FORBIDDEN);
+                throw new BusinessException(MUST_LEADER);
             }
         }
         fieldEntryRepository.deleteById(entryId);

--- a/src/main/java/com/dnd/Exercise/domain/userField/controller/UserFieldController.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/controller/UserFieldController.java
@@ -90,7 +90,7 @@ public class UserFieldController {
             @ApiResponse(code=400, message="[F-008] 필드를 찾을 수 없습니다. "
                     + "<br>[F-004] 매치가 이미 진행 중입니다."),
             @ApiResponse(code=403, message = "[F-012] 팀 멤버가 아닙니다. "
-                    + "<br>[F-013] 팀 리더가 아니어야 합니다.")
+                    + "<br>[F-013] 팀을 나가기 위해서는 다른 팀원에게 방장을 넘겨야 해요.")
     })
     @DeleteMapping("{id}/exit")
     public ResponseEntity<String> exitField(

--- a/src/main/java/com/dnd/Exercise/domain/userField/controller/UserFieldController.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/controller/UserFieldController.java
@@ -150,4 +150,12 @@ public class UserFieldController {
         userFieldService.cheerMember(user ,id);
         return ResponseDto.ok("응원하기 완료");
     }
+
+    @ApiOperation(value = "필드 보유 여부 확인 💡", notes = "자동매칭 전 사용")
+    @GetMapping("/check")
+    public ResponseEntity<String> checkOwnBattle(
+            @AuthenticationPrincipal User user){
+        userFieldService.checkOwnBattle(user);
+        return ResponseDto.ok("보유 여부 확인 완료");
+    }
 }

--- a/src/main/java/com/dnd/Exercise/domain/userField/service/UserFieldService.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/service/UserFieldService.java
@@ -30,4 +30,6 @@ public interface UserFieldService {
     void cheerMember(User user, Long id);
 
     void alertMembers(User user, Long id);
+
+    void checkOwnBattle(User user);
 }

--- a/src/main/java/com/dnd/Exercise/domain/userField/service/UserFieldServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/service/UserFieldServiceImpl.java
@@ -14,6 +14,7 @@ import static com.dnd.Exercise.global.error.dto.ErrorCode.FCM_TIME_LIMIT;
 import static com.dnd.Exercise.global.error.dto.ErrorCode.MUST_NOT_LEADER;
 import static com.dnd.Exercise.global.error.dto.ErrorCode.NOT_FOUND;
 import static com.dnd.Exercise.global.error.dto.ErrorCode.NOT_MEMBER;
+import static com.dnd.Exercise.global.error.dto.ErrorCode.SHOULD_CREATE;
 
 import com.dnd.Exercise.domain.activityRing.repository.ActivityRingRepository;
 import com.dnd.Exercise.domain.exercise.repository.ExerciseRepository;
@@ -271,5 +272,21 @@ public class UserFieldServiceImpl implements UserFieldService {
                 .build();
 
         eventPublisher.publishEvent(new NotificationEvent(members, notificationDto));
+    }
+
+    @Override
+    public void checkOwnBattle(User user) {
+        List<UserField> myUserFields = userFieldRepository.findByUserAndStatusInAndType(user,
+                List.of(RECRUITING, IN_PROGRESS), List.of(TEAM, TEAM_BATTLE));
+
+        List<UserField> result = myUserFields.stream()
+                .filter(userField -> {
+                    Field field = userField.getField();
+                    return field.getOpponent() == null;
+                }).collect(Collectors.toList());
+
+        if (result.isEmpty()){
+            throw new BusinessException(SHOULD_CREATE);
+        }
     }
 }

--- a/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
+++ b/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
@@ -8,13 +8,13 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ErrorCode {
 
-    BAD_REQUEST(HttpStatus.BAD_REQUEST, "C-000", "잘못된 요청"),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "C-000", "잘못된 요청입니다\n다시 한 번 확인해주세요"),
 
     NOT_FOUND(HttpStatus.NOT_FOUND, "C-001", "리소스를 찾을 수 없음"),
 
     METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C-002", "허용되지 않은 Request Method 호출"),
 
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C-003", "내부 서버 오류"),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C-003", "알 수 없는 오류가 발생하였습니다."),
 
     METHOD_ARGUMENT_NOT_VALID(HttpStatus.BAD_REQUEST, "C-004", "요청 인자가 유효하지 않음"),
 
@@ -60,7 +60,7 @@ public enum ErrorCode {
 
     NOT_MEMBER(HttpStatus.FORBIDDEN, "F-012", "팀 멤버가 아닙니다."),
 
-    MUST_NOT_LEADER(HttpStatus.FORBIDDEN, "F-013", "팀 리더가 아니어야 합니다."),
+    MUST_NOT_LEADER(HttpStatus.FORBIDDEN, "F-013", "팀을 나가기 위해서는\n다른 팀원에게 방장을 넘겨야 해요."),
 
     ALREADY_APPLY(HttpStatus.BAD_REQUEST, "FE-001", "이미 신청한 필드입니다."),
 
@@ -69,6 +69,8 @@ public enum ErrorCode {
     ALREADY_FULL(HttpStatus.BAD_REQUEST, "FE-003", "이미 팀원이 가득 찼습니다."),
 
     PERIOD_NOT_MATCH(HttpStatus.BAD_REQUEST, "FE-004", "기간이 같아야 합니다."),
+
+    MUST_LEADER(HttpStatus.FORBIDDEN, "FE-005", "매칭에 대한 설정은 팀장만 가능합니다."),
 
     ACTIVITY_RING_NOT_FOUND(HttpStatus.NOT_FOUND, "AR-001", "해당 날짜에 대한 활동링 소모칼로리 정보가 존재하지 않습니다."),
 

--- a/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
+++ b/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
@@ -64,8 +64,7 @@ public enum ErrorCode {
 
     ALREADY_APPLY(HttpStatus.BAD_REQUEST, "FE-001", "이미 신청한 필드입니다."),
 
-    HAVING_IN_PROGRESS(HttpStatus.BAD_REQUEST, "FE-002", "이미 해당 유형의 필드를 가지고 있습니다. "
-            + "가질 수 있는 최대 필드 수 : 1:1 배틀 1개, 팀 배틀 1개, 팀 1개"),
+    HAVING_IN_PROGRESS(HttpStatus.BAD_REQUEST, "FE-002", "이미 해당 유형의 매칭이 있습니다."),
 
     ALREADY_FULL(HttpStatus.BAD_REQUEST, "FE-003", "이미 팀원이 가득 찼습니다."),
 


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
매칭 시작 시점에 따른 화면 노출 정책을 통일합니다.
배틀 보유 여부 확인 API 추가
에러 메시지 추가 및 변경

## 📋 변경 사항
- 필드 단일 조회 - 상대편 데이터 추가 조건 변경
    - fieldStauts == IN_PRORRESS -> assignedFieldDto == null 
- 배틀 보유 여부 확인 API 추가 - checkOwnBattle
- Patch, Delete 메서드 - 에러 메시지 정책 변경으로 인한 수정 (앱에 그대로 노출)
- Delete, Patch 메서드 에러 메시지 피그마와 통일
    - 팀을 나가기 위해서는\n다른 팀원에게 방장을 넘겨야 해요.
    - ”알 수 없는 오류가 발생하였습니다.”, “잘못된 요청입니다.\n다시 한 번 확인해주세요” 로 에러 메시지 변경
- MultipartFile Post 메서드로 변경

## 🔍 Code Review
코드 리뷰 시에 주요 확인 사항을 작성해주세요.

## 연결된 이슈 Close
close #85 
