### PR TITLE
Feat: 불꽃평가 관련 API 구현

### DIFF
--- a/src/main/java/com/dnd/Exercise/domain/field/dto/response/FindFieldResultRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/dto/response/FindFieldResultRes.java
@@ -22,4 +22,6 @@ public class FindFieldResultRes {
     private FindFieldResultDto home;
 
     private FindFieldResultDto away;
+
+    private int teamworkRate;
 }

--- a/src/main/java/com/dnd/Exercise/domain/field/service/FieldServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/service/FieldServiceImpl.java
@@ -46,6 +46,7 @@ import com.dnd.Exercise.domain.field.entity.enums.RankCriterion;
 import com.dnd.Exercise.domain.field.entity.enums.WinStatus;
 import com.dnd.Exercise.domain.field.repository.FieldRepository;
 import com.dnd.Exercise.domain.fieldEntry.repository.FieldEntryRepository;
+import com.dnd.Exercise.domain.teamworkRate.service.TeamworkRateService;
 import com.dnd.Exercise.domain.user.entity.User;
 import com.dnd.Exercise.domain.user.repository.UserRepository;
 import com.dnd.Exercise.domain.userField.entity.UserField;
@@ -83,6 +84,7 @@ public class FieldServiceImpl implements FieldService{
     private final AwsS3Service awsS3Service;
     private final FieldUtil fieldUtil;
     private final UserRepository userRepository;
+    private final TeamworkRateService teamworkRateService;
     private final String S3_FOLDER = "field-profile";
 
 
@@ -472,7 +474,8 @@ public class FieldServiceImpl implements FieldService{
         FindFieldResultDto home = new FindFieldResultDto(myField, score);
         FindFieldResultRes.FindFieldResultResBuilder resBuilder= FindFieldResultRes.builder()
                 .period(myField.getPeriod())
-                .home(home);
+                .home(home)
+                .teamworkRate(teamworkRateService.getTeamworkRateOfField(myField));
 
         if (!TEAM.equals(myField.getFieldType())){
             Field opponentField = myField.getOpponent();

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/controller/TeamworkRateController.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/controller/TeamworkRateController.java
@@ -38,6 +38,17 @@ public class TeamworkRateController {
         return ResponseDto.ok("불꽃평가 등록 완료");
     }
 
+    @ApiOperation(value = "필드에 대한 유저의 평가 완료 여부 확인 💯", notes = "해당 필드에 대한 유저의 불꽃평가 완료 여부를 반환합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 400, message = "[F-011] 완료된 필드가 아닙니다. <br>" +
+                    "[F-012] 팀 멤버가 아닙니다.")
+    })
+    @GetMapping("/is-rating-done")
+    public ResponseEntity<Boolean> getIsRatingDone(@RequestParam Long fieldId, @AuthenticationPrincipal User user) {
+        Boolean isRatingDone = teamworkRateService.getIsRatingDone(fieldId, user);
+        return ResponseEntity.ok(isRatingDone);
+    }
+
     @ApiOperation(value = "불꽃 히스토리 확인 💯", notes = "마이페이지에서 불꽃 히스토리를 확인합니다.")
     @GetMapping("/history")
     public ResponseEntity<GetTeamworkRateHistoryRes> getTeamworkRateHistory(@RequestParam(required = false) FieldType fieldType, @RequestParam Integer page, @RequestParam Integer size,

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/controller/TeamworkRateController.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/controller/TeamworkRateController.java
@@ -1,0 +1,41 @@
+package com.dnd.Exercise.domain.teamworkRate.controller;
+
+import com.dnd.Exercise.domain.teamworkRate.dto.request.PostTeamworkRateReq;
+import com.dnd.Exercise.domain.teamworkRate.service.TeamworkRateService;
+import com.dnd.Exercise.domain.user.entity.User;
+import com.dnd.Exercise.global.common.ResponseDto;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@Api(tags = "불꽃 평가 💯")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/teamwork-rate")
+public class TeamworkRateController {
+
+    private final TeamworkRateService teamworkRateService;
+
+    @ApiOperation(value = "매칭 종료 시, 불꽃평가 등록 💯", notes = "1~5 점 사이로 불꽃 평가를 등록합니다.")
+    @ApiResponses({
+            @ApiResponse(code = 200, message = "불꽃평가 등록 완료"),
+            @ApiResponse(code = 400, message = "[TR-001] 해당 유저는 이미 불꽃평가 등록을 완료했습니다. <br>" +
+                    "[F-011] 완료된 필드가 아닙니다. <br>" +
+                    "[F-012] 팀 멤버가 아닙니다.")
+    })
+    @PostMapping
+    public ResponseEntity<String> postTeamworkRate(@RequestBody @Valid PostTeamworkRateReq postTeamworkRateReq, @AuthenticationPrincipal User user) {
+        teamworkRateService.postTeamworkRate(postTeamworkRateReq, user);
+        return ResponseDto.ok("불꽃평가 등록 완료");
+    }
+}

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/controller/TeamworkRateController.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/controller/TeamworkRateController.java
@@ -1,6 +1,8 @@
 package com.dnd.Exercise.domain.teamworkRate.controller;
 
+import com.dnd.Exercise.domain.field.entity.enums.FieldType;
 import com.dnd.Exercise.domain.teamworkRate.dto.request.PostTeamworkRateReq;
+import com.dnd.Exercise.domain.teamworkRate.dto.response.GetTeamworkRateHistoryRes;
 import com.dnd.Exercise.domain.teamworkRate.service.TeamworkRateService;
 import com.dnd.Exercise.domain.user.entity.User;
 import com.dnd.Exercise.global.common.ResponseDto;
@@ -11,10 +13,7 @@ import io.swagger.annotations.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 
@@ -37,5 +36,13 @@ public class TeamworkRateController {
     public ResponseEntity<String> postTeamworkRate(@RequestBody @Valid PostTeamworkRateReq postTeamworkRateReq, @AuthenticationPrincipal User user) {
         teamworkRateService.postTeamworkRate(postTeamworkRateReq, user);
         return ResponseDto.ok("불꽃평가 등록 완료");
+    }
+
+    @ApiOperation(value = "불꽃 히스토리 확인 💯", notes = "마이페이지에서 불꽃 히스토리를 확인합니다.")
+    @GetMapping("/history")
+    public ResponseEntity<GetTeamworkRateHistoryRes> getTeamworkRateHistory(@RequestParam(required = false) FieldType fieldType, @RequestParam Integer page, @RequestParam Integer size,
+                                                                            @AuthenticationPrincipal User user) {
+        GetTeamworkRateHistoryRes getTeamworkRateHistoryRes = teamworkRateService.getTeamworkRateHistory(fieldType,page,size,user);
+        return ResponseEntity.ok(getTeamworkRateHistoryRes);
     }
 }

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/dto/TeamworkRateMapper.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/dto/TeamworkRateMapper.java
@@ -1,0 +1,20 @@
+package com.dnd.Exercise.domain.teamworkRate.dto;
+
+import com.dnd.Exercise.domain.field.entity.Field;
+import com.dnd.Exercise.domain.field.entity.enums.WinStatus;
+import com.dnd.Exercise.domain.teamworkRate.dto.response.TeamworkRateHistoryDto;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.NullValueMappingStrategy;
+
+@Mapper(componentModel = "spring", nullValueMapMappingStrategy = NullValueMappingStrategy.RETURN_NULL)
+public interface TeamworkRateMapper {
+    @Mapping(source = "field.fieldType", target = "fieldType")
+    @Mapping(source = "field.name", target = "myFieldName")
+    @Mapping(source = "field.opponent.name", target = "opponentName")
+    @Mapping(source = "field.period", target = "period")
+    @Mapping(source = "field.endDate", target = "endDate")
+    @Mapping(source = "teamworkRate", target = "teamworkRate")
+    @Mapping(source = "winStatus", target = "winStatus")
+    TeamworkRateHistoryDto from(Field field, Integer teamworkRate, WinStatus winStatus);
+}

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/dto/request/PostTeamworkRateReq.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/dto/request/PostTeamworkRateReq.java
@@ -1,0 +1,22 @@
+package com.dnd.Exercise.domain.teamworkRate.dto.request;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.Max;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+@Getter
+@NoArgsConstructor
+public class PostTeamworkRateReq {
+    @ApiModelProperty(value = "필드 id", required = true)
+    @NotNull
+    private long fieldId;
+
+    @ApiModelProperty(value = "불꽃 평가 점수 (1~5점)", required = true)
+    @NotNull
+    @Min(1) @Max(5)
+    private int teamworkRate;
+}

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/dto/response/GetTeamworkRateHistoryRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/dto/response/GetTeamworkRateHistoryRes.java
@@ -1,0 +1,22 @@
+package com.dnd.Exercise.domain.teamworkRate.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class GetTeamworkRateHistoryRes {
+    List<TeamworkRateHistoryDto> teamworkRateHistoryDtos;
+
+    private int currentPage;
+    private int currentPageSize;
+
+    private Boolean isFirstPage;
+    private Boolean isLastPage;
+}

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/dto/response/TeamworkRateHistoryDto.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/dto/response/TeamworkRateHistoryDto.java
@@ -1,0 +1,30 @@
+package com.dnd.Exercise.domain.teamworkRate.dto.response;
+
+import com.dnd.Exercise.domain.field.entity.enums.FieldType;
+import com.dnd.Exercise.domain.field.entity.enums.Period;
+import com.dnd.Exercise.domain.field.entity.enums.WinStatus;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TeamworkRateHistoryDto {
+
+    private FieldType fieldType;
+
+    private String myFieldName;
+
+    private String opponentName;
+
+    private Period period;
+
+    private LocalDate endDate;
+
+    private Integer teamworkRate;
+
+    private WinStatus winStatus;
+}

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/entity/TeamworkRate.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/entity/TeamworkRate.java
@@ -2,7 +2,10 @@ package com.dnd.Exercise.domain.teamworkRate.entity;
 
 import com.dnd.Exercise.domain.field.entity.Field;
 import com.dnd.Exercise.domain.user.entity.User;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
@@ -10,6 +13,7 @@ import static javax.persistence.FetchType.LAZY;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TeamworkRate {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -25,4 +29,11 @@ public class TeamworkRate {
     private Field field;
 
     private int rate;
+
+    @Builder
+    public TeamworkRate(User user, Field field, int rate) {
+        this.submitUser = user;
+        this.field = field;
+        this.rate = rate;
+    }
 }

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/repository/TeamworkRateRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/repository/TeamworkRateRepository.java
@@ -1,0 +1,24 @@
+package com.dnd.Exercise.domain.teamworkRate.repository;
+
+import com.dnd.Exercise.domain.field.entity.Field;
+import com.dnd.Exercise.domain.teamworkRate.entity.TeamworkRate;
+import com.dnd.Exercise.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface TeamworkRateRepository extends JpaRepository<TeamworkRate, Long> {
+
+    Boolean existsByFieldAndSubmitUser(Field field, User submitUser);
+
+    Boolean existsByField(Field field);
+
+    @Query("select avg(tr.rate) " +
+            "from TeamworkRate tr " +
+            "where tr.field.id = :fieldId")
+    Double getAvgRateOfField(Long fieldId);
+
+    @Query("select tr.rate " +
+            "from TeamworkRate tr " +
+            "where tr.field.id = :fieldId")
+    int getRateOfField(Long fieldId);
+}

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateService.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateService.java
@@ -9,5 +9,6 @@ import com.dnd.Exercise.domain.user.entity.User;
 public interface TeamworkRateService {
     void postTeamworkRate(PostTeamworkRateReq postTeamworkRateReq, User user);
     int getTeamworkRateOfField(Field field);
+    Boolean getIsRatingDone(Long fieldId, User user);
     GetTeamworkRateHistoryRes getTeamworkRateHistory(FieldType fieldType, Integer page, Integer size, User user);
 }

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateService.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateService.java
@@ -1,10 +1,13 @@
 package com.dnd.Exercise.domain.teamworkRate.service;
 
 import com.dnd.Exercise.domain.field.entity.Field;
+import com.dnd.Exercise.domain.field.entity.enums.FieldType;
 import com.dnd.Exercise.domain.teamworkRate.dto.request.PostTeamworkRateReq;
+import com.dnd.Exercise.domain.teamworkRate.dto.response.GetTeamworkRateHistoryRes;
 import com.dnd.Exercise.domain.user.entity.User;
 
 public interface TeamworkRateService {
     void postTeamworkRate(PostTeamworkRateReq postTeamworkRateReq, User user);
     int getTeamworkRateOfField(Field field);
+    GetTeamworkRateHistoryRes getTeamworkRateHistory(FieldType fieldType, Integer page, Integer size, User user);
 }

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateService.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateService.java
@@ -1,8 +1,10 @@
 package com.dnd.Exercise.domain.teamworkRate.service;
 
+import com.dnd.Exercise.domain.field.entity.Field;
 import com.dnd.Exercise.domain.teamworkRate.dto.request.PostTeamworkRateReq;
 import com.dnd.Exercise.domain.user.entity.User;
 
 public interface TeamworkRateService {
     void postTeamworkRate(PostTeamworkRateReq postTeamworkRateReq, User user);
+    int getTeamworkRateOfField(Field field);
 }

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateService.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateService.java
@@ -1,0 +1,8 @@
+package com.dnd.Exercise.domain.teamworkRate.service;
+
+import com.dnd.Exercise.domain.teamworkRate.dto.request.PostTeamworkRateReq;
+import com.dnd.Exercise.domain.user.entity.User;
+
+public interface TeamworkRateService {
+    void postTeamworkRate(PostTeamworkRateReq postTeamworkRateReq, User user);
+}

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateServiceImpl.java
@@ -58,6 +58,13 @@ public class TeamworkRateServiceImpl implements TeamworkRateService {
         }
     }
 
+    @Override
+    @Transactional
+    public int getTeamworkRateOfField(Field field) {
+        int teamworkRateOfField = getRateGainOfField(field);
+        return teamworkRateOfField;
+    }
+
     private void validateIsFieldCompleted(Field field) {
         if (!COMPLETED.equals(field.getFieldStatus())) {
             throw new BusinessException(NOT_COMPLETED);

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateServiceImpl.java
@@ -1,0 +1,125 @@
+package com.dnd.Exercise.domain.teamworkRate.service;
+
+import com.dnd.Exercise.domain.field.entity.Field;
+import com.dnd.Exercise.domain.field.entity.enums.FieldType;
+import com.dnd.Exercise.domain.teamworkRate.dto.request.PostTeamworkRateReq;
+import com.dnd.Exercise.domain.teamworkRate.entity.TeamworkRate;
+import com.dnd.Exercise.domain.teamworkRate.repository.TeamworkRateRepository;
+import com.dnd.Exercise.domain.user.entity.User;
+import com.dnd.Exercise.domain.user.repository.UserRepository;
+import com.dnd.Exercise.domain.userField.entity.UserField;
+import com.dnd.Exercise.domain.userField.repository.UserFieldRepository;
+import com.dnd.Exercise.global.error.exception.BusinessException;
+import com.dnd.Exercise.global.util.field.FieldUtil;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.dnd.Exercise.domain.field.entity.enums.FieldStatus.COMPLETED;
+import static com.dnd.Exercise.global.error.dto.ErrorCode.NOT_COMPLETED;
+import static com.dnd.Exercise.global.error.dto.ErrorCode.TEAMWORK_RATE_POSTED_ALREADY;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TeamworkRateServiceImpl implements TeamworkRateService {
+
+    private final TeamworkRateRepository teamworkRateRepository;
+    private final UserFieldRepository userFieldRepository;
+    private final UserRepository userRepository;
+    private final FieldUtil fieldUtil;
+
+    @Override
+    @Transactional
+    public void postTeamworkRate(PostTeamworkRateReq postTeamworkRateReq, User user) {
+        long fieldId = postTeamworkRateReq.getFieldId();
+        int teamworkRate = postTeamworkRateReq.getTeamworkRate();
+
+        Field field = fieldUtil.getField(fieldId);
+        FieldType fieldType = field.getFieldType();
+
+        fieldUtil.validateIsMember(user, field);
+        validateIsFieldCompleted(field);
+        validateIsPostingUndone(field, user);
+
+        teamworkRateRepository.save(TeamworkRate.builder()
+                .user(user)
+                .field(field)
+                .rate(teamworkRate)
+                .build());
+
+        if (fieldType == FieldType.TEAM_BATTLE || fieldType == FieldType.TEAM) {
+            updateRatingOfTeamMembers(field);
+        } else if (fieldType == FieldType.DUEL) {
+            updateRatingOfOpponent(field);
+        }
+    }
+
+    private void validateIsFieldCompleted(Field field) {
+        if (!COMPLETED.equals(field.getFieldStatus())) {
+            throw new BusinessException(NOT_COMPLETED);
+        }
+    }
+
+    private void validateIsPostingUndone(Field field, User user) {
+        if (teamworkRateRepository.existsByFieldAndSubmitUser(field, user)) {
+            throw new BusinessException(TEAMWORK_RATE_POSTED_ALREADY);
+        }
+    }
+
+    private void updateRatingOfTeamMembers(Field field) {
+        List<User> teamMembers = fieldUtil.getMembers(field.getId());
+        teamMembers.forEach(user -> updateTeamworkRateOfUser(user));
+    }
+
+    private void updateRatingOfOpponent(Field field) {
+        Field opponentField = field.getOpponent();
+        User opponentUser = userRepository.findById(opponentField.getLeaderId()).get();
+        updateTeamworkRateOfUser(opponentUser);
+    }
+
+    private void updateTeamworkRateOfUser(User user) {
+        List<Field> completedFields = getCompletedFieldsOfUser(user);
+
+        List<Integer> rateGainOfFields = completedFields.stream()
+                .map(field -> getRateGainOfField(field))
+                .collect(Collectors.toList());
+
+        int totalRateGain = rateGainOfFields.stream().mapToInt(Integer::intValue).sum();
+        int totalRatedField = Long.valueOf(rateGainOfFields.stream().filter(rateGain -> rateGain > 0).count()).intValue();
+
+        int newTeamworkRate = totalRateGain / totalRatedField;
+        user.updateTeamworkRate(newTeamworkRate);
+    }
+
+    private List<Field> getCompletedFieldsOfUser(User user) {
+        List<UserField> userFields = userFieldRepository.findAllByUser(user);
+        List<Field> completedFields = userFields.stream()
+                .map(UserField::getField)
+                .filter(field -> field.getFieldStatus() == COMPLETED)
+                .collect(Collectors.toList());
+        return completedFields;
+    }
+
+    private int getRateGainOfField(Field field) {
+        FieldType fieldType = field.getFieldType();
+        Long fieldId = field.getId();
+        int rateGain = 0;
+
+        if (fieldType == FieldType.TEAM_BATTLE || fieldType == FieldType.TEAM) {
+            if (teamworkRateRepository.existsByField(field)) {
+                Double avgRate = teamworkRateRepository.getAvgRateOfField(fieldId);
+                rateGain = Long.valueOf(Math.round(avgRate)).intValue();
+            }
+        } else if (fieldType == FieldType.DUEL) {
+            Field opponentField = field.getOpponent();
+            if (teamworkRateRepository.existsByField(opponentField)) {
+                rateGain = teamworkRateRepository.getRateOfField(opponentField.getId());
+            }
+        }
+        return rateGain;
+    }
+}

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateServiceImpl.java
@@ -136,10 +136,9 @@ public class TeamworkRateServiceImpl implements TeamworkRateService {
     }
 
     private List<Field> getCompletedFieldsOfUser(User user) {
-        List<UserField> userFields = userFieldRepository.findAllByUser(user);
+        List<UserField> userFields = userFieldRepository.findAllByUserAndFieldStatus(user, COMPLETED);
         List<Field> completedFields = userFields.stream()
                 .map(UserField::getField)
-                .filter(field -> field.getFieldStatus() == COMPLETED)
                 .collect(Collectors.toList());
         return completedFields;
     }

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateServiceImpl.java
@@ -19,6 +19,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -75,7 +76,7 @@ public class TeamworkRateServiceImpl implements TeamworkRateService {
 
     @Override
     public GetTeamworkRateHistoryRes getTeamworkRateHistory(FieldType fieldType, Integer page, Integer size, User user) {
-        Pageable pageable = PageRequest.of(page,size);
+        Pageable pageable = PageRequest.of(page,size, Sort.by("field.endDate").descending());
         Page<UserField> pagedUserFields = userFieldRepository.findCompletedFieldByUserAndType(user,fieldType,pageable);
 
         List<Field> completedFields = pagedUserFields.getContent()

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateServiceImpl.java
@@ -75,6 +75,17 @@ public class TeamworkRateServiceImpl implements TeamworkRateService {
     }
 
     @Override
+    public Boolean getIsRatingDone(Long fieldId, User user) {
+        Field field = fieldUtil.getField(fieldId);
+
+        fieldUtil.validateIsMember(user, field);
+        validateIsFieldCompleted(field);
+
+        if (teamworkRateRepository.existsByFieldAndSubmitUser(field, user)) { return true; }
+        return false;
+    }
+
+    @Override
     public GetTeamworkRateHistoryRes getTeamworkRateHistory(FieldType fieldType, Integer page, Integer size, User user) {
         Pageable pageable = PageRequest.of(page,size, Sort.by("field.endDate").descending());
         Page<UserField> pagedUserFields = userFieldRepository.findCompletedFieldByUserAndType(user,fieldType,pageable);

--- a/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/teamworkRate/service/TeamworkRateServiceImpl.java
@@ -68,7 +68,6 @@ public class TeamworkRateServiceImpl implements TeamworkRateService {
     }
 
     @Override
-    @Transactional
     public int getTeamworkRateOfField(Field field) {
         int teamworkRateOfField = getRateGainOfField(field);
         return teamworkRateOfField;

--- a/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
@@ -138,4 +138,6 @@ public class User extends BaseEntity implements UserDetails {
     public void updatePassword(String password) {
         this.password = password;
     }
+
+    public void updateTeamworkRate(int teamworkRate) { this.teamworkRate = teamworkRate; }
 }

--- a/src/main/java/com/dnd/Exercise/domain/userField/controller/UserFieldController.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/controller/UserFieldController.java
@@ -18,7 +18,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.data.web.SortDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -62,7 +64,7 @@ public class UserFieldController {
     public ResponseEntity<FindAllMyCompletedFieldsRes> findAllMyCompletedFields(
             @AuthenticationPrincipal User user,
             @RequestParam(value = "fieldType", required = false) FieldType fieldType,
-            @PageableDefault(page = 0, size = 5) Pageable pageable){
+            @PageableDefault(page = 0, size = 5) @SortDefault(sort = "field.createdAt", direction = Sort.Direction.ASC) Pageable pageable){
         FindAllMyCompletedFieldsRes result = userFieldService.findAllMyCompletedFields(user, fieldType, pageable);
         return ResponseDto.ok(result);
     }

--- a/src/main/java/com/dnd/Exercise/domain/userField/repository/UserFieldRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/repository/UserFieldRepository.java
@@ -45,4 +45,10 @@ public interface UserFieldRepository extends JpaRepository<UserField, Long>, Use
     void deleteAllByFieldAndUserIdIn(Field field, List<Long> targetUserIds);
 
     void deleteByFieldAndUser(Field field, User user);
+
+    @Query("select uf " +
+            "from UserField uf join fetch uf.field " +
+            "where uf.user = :user " +
+            "and uf.field.fieldStatus = :fieldStatus")
+    List<UserField> findAllByUserAndFieldStatus(User user, FieldStatus fieldStatus);
 }

--- a/src/main/java/com/dnd/Exercise/domain/userField/repository/UserFieldRepositoryImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/repository/UserFieldRepositoryImpl.java
@@ -29,7 +29,7 @@ public class UserFieldRepositoryImpl implements UserFieldRepositoryCustom{
         JPAQuery<Long> countQuery = queryFactory
                 .select(userField.count())
                 .from(userField)
-                .join(userField.field, field).fetchJoin()
+                .join(userField.field, field)
                 .where(userField.user.id.eq(user.getId()))
                 .where(userField.field.fieldStatus.eq(COMPLETED),
                         evaluateEq(userField.field.fieldType, fieldType));

--- a/src/main/java/com/dnd/Exercise/domain/userField/repository/UserFieldRepositoryImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/repository/UserFieldRepositoryImpl.java
@@ -8,12 +8,18 @@ import static com.dnd.Exercise.domain.userField.entity.QUserField.userField;
 import com.dnd.Exercise.domain.field.entity.enums.FieldType;
 import com.dnd.Exercise.domain.user.entity.User;
 import com.dnd.Exercise.domain.userField.entity.UserField;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
@@ -40,11 +46,23 @@ public class UserFieldRepositoryImpl implements UserFieldRepositoryCustom{
                 .where(userField.user.id.eq(user.getId()))
                 .where(userField.field.fieldStatus.eq(COMPLETED),
                         evaluateEq(userField.field.fieldType, fieldType))
-                .orderBy(field.createdAt.asc())
+                .orderBy(getOrderSpecifiers(pageable.getSort()).stream().toArray(OrderSpecifier[]::new))
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
 
         return PageableExecutionUtils.getPage(results, pageable, countQuery::fetchOne);
+    }
+
+    private List<OrderSpecifier> getOrderSpecifiers(Sort sort) {
+        List<OrderSpecifier> orderSpecifiers = new ArrayList<>();
+
+        sort.forEach(orderCond -> {
+            Order direction = orderCond.isAscending() ? Order.ASC : Order.DESC;
+            String property = orderCond.getProperty();
+            PathBuilder orderByExpression = new PathBuilder(UserField.class, "userField");
+            orderSpecifiers.add(new OrderSpecifier(direction, orderByExpression.get(property)));
+        });
+        return orderSpecifiers;
     }
 }

--- a/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
+++ b/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
@@ -106,7 +106,9 @@ public enum ErrorCode {
 
     UNMATCHING_PHONE_NUM(HttpStatus.BAD_REQUEST, "V-006", "회원정보에 등록된 전화번호와 일치하지 않습니다."),
 
-    INVALID_KAKAO_TOKEN(HttpStatus.UNAUTHORIZED, "K-001", "해당 액세스 토큰으로 카카오 유저 정보를 받아오지 못했습니다.");
+    INVALID_KAKAO_TOKEN(HttpStatus.UNAUTHORIZED, "K-001", "해당 액세스 토큰으로 카카오 유저 정보를 받아오지 못했습니다."),
+
+    TEAMWORK_RATE_POSTED_ALREADY(HttpStatus.BAD_REQUEST, "TR-001", "해당 유저는 이미 불꽃평가 등록을 완료했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/dnd/Exercise/global/util/field/FieldUtil.java
+++ b/src/main/java/com/dnd/Exercise/global/util/field/FieldUtil.java
@@ -2,6 +2,7 @@ package com.dnd.Exercise.global.util.field;
 
 import static com.dnd.Exercise.domain.field.entity.enums.FieldStatus.IN_PROGRESS;
 import static com.dnd.Exercise.domain.field.entity.enums.FieldStatus.RECRUITING;
+import static com.dnd.Exercise.domain.field.entity.enums.FieldType.TEAM;
 import static com.dnd.Exercise.global.error.dto.ErrorCode.ALREADY_IN_PROGRESS;
 import static com.dnd.Exercise.global.error.dto.ErrorCode.FIELD_NOT_FOUND;
 import static com.dnd.Exercise.global.error.dto.ErrorCode.HAVING_IN_PROGRESS;
@@ -16,6 +17,7 @@ import com.dnd.Exercise.domain.exercise.entity.Exercise;
 import com.dnd.Exercise.domain.exercise.repository.ExerciseRepository;
 import com.dnd.Exercise.domain.field.entity.Field;
 import com.dnd.Exercise.domain.field.entity.enums.FieldType;
+import com.dnd.Exercise.domain.field.entity.enums.WinStatus;
 import com.dnd.Exercise.domain.field.repository.FieldRepository;
 import com.dnd.Exercise.domain.user.entity.User;
 import com.dnd.Exercise.domain.userField.entity.UserField;
@@ -24,6 +26,8 @@ import com.dnd.Exercise.global.error.exception.BusinessException;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -116,6 +120,22 @@ public class FieldUtil {
         List<Exercise> exercises = getExercises(startDate, endDate, memberIds);
 
         return calculateRecord(activityRings, exercises);
+    }
+
+    public WinStatus getFieldWinStatus(Field field) {
+        if (TEAM.equals(field.getFieldType())) {
+            return null;
+        }
+        Field opponent = field.getOpponent();
+        List<Integer> myScores = getFieldSummary(field.getId(),field.getStartDate(),field.getEndDate());
+        List<Integer> opponentScores = getFieldSummary(opponent.getId(),opponent.getStartDate(),opponent.getEndDate());
+
+        int result = IntStream.range(0, myScores.size())
+                .map(i -> Integer.compare(myScores.get(i), opponentScores.get(i))).sum();
+
+        if (result > 0) return WinStatus.WIN;
+        if (result < 0) return WinStatus.LOSE;
+        return WinStatus.DRAW;
     }
 
     public void validateNotHavingField(User user, FieldType fieldType){


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
불꽃평가 관련 API 를 구현합니다.
- (매칭 종료 시) 불꽃평가 등록
- (매칭 종료 후 평가까지 완료된 팀에 대해) 불꽃평가 결과 불러오기
 - (마이페이지) 불꽃 히스토리 조회
 - 특정 필드에 대한 평가 완료 여부 확인

## 📋 변경 사항
- `TeamworkRateController`
    - `postTeamworkRate`
    - `getIsRatingDone`
    - `getTeamworkRateHistory`

## 🔍 Code Review
- '(매칭 종료 후 평가까지 완료된 팀에 대해) 불꽃평가 결과 불러오기' 구현을 위해 수정한 사항입니다. 📍관련커밋: c786085
    - `FindFieldResultRes`
    - FieldServiceImpl - `findFieldResult()`
    - (해당 부분 수정하는게 맞는지 확인 부탁드립니다...! 🙏🏻🙇🏻‍♀️)
- FieldUtil 에 필드의 승부 가져오는 함수 추가하였습니다. 📍관련커밋: ba52c0c
    - FieldUtil - `getFieldWinStatus()`
- 불꽃 히스토리 구현 시 UserFieldRepositoryImpl 의 `findCompletedFieldByUserAndType()` 함수를 사용
    - 기존 정렬 기준과 다르게 적용하기 위해 동적 정렬로 쿼리 수정하였습니다. 📍관련커밋: f458a77
    - countQuery 에서 fetch join 제거 📍관련커밋: 6e05ac7

## 📸 ScreenShot

## 연결된 이슈 Close
close #91
