### PR TITLE
Feat: 마이페이지 관련 API 구현

### DIFF
--- a/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/exercise/repository/ExerciseRepository.java
@@ -37,4 +37,6 @@ public interface ExerciseRepository extends JpaRepository<Exercise, Long>, Exerc
     int sumDailyDurationMinuteOfUser(LocalDate exerciseDate, long userId);
 
     int countByExerciseDateAndUserId(LocalDate exerciseDate, long userId);
+
+    int countByUserId(long userId);
 }

--- a/src/main/java/com/dnd/Exercise/domain/field/entity/Field.java
+++ b/src/main/java/com/dnd/Exercise/domain/field/entity/Field.java
@@ -114,6 +114,10 @@ public class Field extends BaseEntity {
         this.currentSize += 1;
     }
 
+    public void subtractMember() {
+        this.currentSize -= 1;
+    }
+
     public void changeProfileImg(String imgUrl){
         this.profileImg = imgUrl;
     }

--- a/src/main/java/com/dnd/Exercise/domain/fieldEntry/repository/FieldEntryRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/fieldEntry/repository/FieldEntryRepository.java
@@ -24,6 +24,8 @@ public interface FieldEntryRepository extends JpaRepository<FieldEntry, Long>, F
 
     void deleteAllByEntrantField(Field field);
 
+    void deleteAllByHostField(Field field);
+
     @EntityGraph(attributePaths = "hostField")
     Page<FieldEntry> findByEntrantUser(User user, Pageable pageable);
 

--- a/src/main/java/com/dnd/Exercise/domain/fieldEntry/service/FieldEntryServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/fieldEntry/service/FieldEntryServiceImpl.java
@@ -154,6 +154,8 @@ public class FieldEntryServiceImpl implements FieldEntryService {
         Field hostField = fieldEntry.getHostField();
         User entrantUser = fieldEntry.getEntrantUser();
 
+        fieldUtil.validateIsFull(hostField);
+        fieldUtil.validateIsFull(entrantField);
         fieldUtil.validateIsLeader(user.getId(), hostField.getLeaderId());
 
         if(entrantField == null) {

--- a/src/main/java/com/dnd/Exercise/domain/user/controller/UserController.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.dnd.Exercise.domain.user.controller;
 
 import com.dnd.Exercise.domain.user.dto.request.*;
+import com.dnd.Exercise.domain.user.dto.response.GetFinalSummaryRes;
 import com.dnd.Exercise.domain.user.dto.response.GetProfileDetail;
 import com.dnd.Exercise.domain.user.entity.User;
 import com.dnd.Exercise.domain.user.service.UserService;
@@ -106,5 +107,12 @@ public class UserController {
     public ResponseEntity<String> withdraw(@AuthenticationPrincipal User user) {
         userService.withdraw(user.getId());
         return ResponseDto.ok("회원 탈퇴 완료");
+    }
+
+    @ApiOperation(value = "회원 탈퇴 전 유저의 활동 내역 요약 👤", notes = "회원 탈퇴 전에 유저의 활동 내역을 보여줍니다.")
+    @GetMapping("/my/final-summary")
+    public ResponseEntity<GetFinalSummaryRes> getFinalSummary(@AuthenticationPrincipal User user) {
+        GetFinalSummaryRes getFinalSummaryRes = userService.getFinalSummary(user.getId());
+        return ResponseDto.ok(getFinalSummaryRes);
     }
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/controller/UserController.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/controller/UserController.java
@@ -95,4 +95,16 @@ public class UserController {
         userService.updateNotificationAgreed(updateNotificationAgreementReq, user.getId());
         return ResponseDto.ok("알림 수신여부 수정 완료");
     }
+
+    @ApiOperation(value = "회원 탈퇴 👤", notes = "유저 탈퇴를 진행합니다. 진행 중인 매칭이 있다면 매칭이 완료된 후에 탈퇴할 수 있습니다.")
+    @ApiResponses({
+            @ApiResponse(code=200, message="회원 탈퇴 완료"),
+            @ApiResponse(code=400, message="[U-003] 진행 중인 매칭이 완료된 후에 탈퇴해 주세요. <br>" +
+                    "[U-004] 내가 속한 팀의 방장을 누군가에게 넘긴 후 탈퇴해 주세요.")
+    })
+    @GetMapping("/my/withdraw")
+    public ResponseEntity<String> withdraw(@AuthenticationPrincipal User user) {
+        userService.withdraw(user.getId());
+        return ResponseDto.ok("회원 탈퇴 완료");
+    }
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/controller/UserController.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/controller/UserController.java
@@ -2,6 +2,7 @@ package com.dnd.Exercise.domain.user.controller;
 
 import com.dnd.Exercise.domain.user.dto.request.*;
 import com.dnd.Exercise.domain.user.dto.response.GetFinalSummaryRes;
+import com.dnd.Exercise.domain.user.dto.response.GetMatchSummaryRes;
 import com.dnd.Exercise.domain.user.dto.response.GetProfileDetail;
 import com.dnd.Exercise.domain.user.entity.User;
 import com.dnd.Exercise.domain.user.service.UserService;
@@ -114,5 +115,12 @@ public class UserController {
     public ResponseEntity<GetFinalSummaryRes> getFinalSummary(@AuthenticationPrincipal User user) {
         GetFinalSummaryRes getFinalSummaryRes = userService.getFinalSummary(user.getId());
         return ResponseDto.ok(getFinalSummaryRes);
+    }
+
+    @ApiOperation(value = "유저의 매칭 요약 👤", notes = "지금까지의 매칭 참여 횟수, 매칭 승률을 반환합니다.")
+    @GetMapping("/my/match-summary")
+    public ResponseEntity<GetMatchSummaryRes> getMatchSummary(@AuthenticationPrincipal User user) {
+        GetMatchSummaryRes getMatchSummaryRes = userService.getMatchSummary(user.getId());
+        return ResponseDto.ok(getMatchSummaryRes);
     }
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/controller/UserController.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.dnd.Exercise.domain.user.dto.request.*;
 import com.dnd.Exercise.domain.user.dto.response.GetFinalSummaryRes;
 import com.dnd.Exercise.domain.user.dto.response.GetMatchSummaryRes;
 import com.dnd.Exercise.domain.user.dto.response.GetProfileDetail;
+import com.dnd.Exercise.domain.user.entity.LoginType;
 import com.dnd.Exercise.domain.user.entity.User;
 import com.dnd.Exercise.domain.user.service.UserService;
 import com.dnd.Exercise.global.common.ResponseDto;
@@ -122,5 +123,12 @@ public class UserController {
     public ResponseEntity<GetMatchSummaryRes> getMatchSummary(@AuthenticationPrincipal User user) {
         GetMatchSummaryRes getMatchSummaryRes = userService.getMatchSummary(user.getId());
         return ResponseDto.ok(getMatchSummaryRes);
+    }
+
+    @ApiOperation(value = "연결된 계정 정보 확인 👤", notes = "현재 연결된 계정 정보를 반환합니다. (ex. 카카오 / 구글 / 애플 / 매치업)")
+    @GetMapping("/my/connected-account")
+    public ResponseEntity<LoginType> getConnectedAccount(@AuthenticationPrincipal User user) {
+        LoginType loginType = user.getLoginType();
+        return ResponseDto.ok(loginType);
     }
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/response/GetFinalSummaryRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/response/GetFinalSummaryRes.java
@@ -1,0 +1,17 @@
+package com.dnd.Exercise.domain.user.dto.response;
+
+import lombok.*;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class GetFinalSummaryRes {
+    private int activeDays;
+
+    private int recordCounts;
+
+    private int matchCounts;
+
+    private int teamworkRate;
+}

--- a/src/main/java/com/dnd/Exercise/domain/user/dto/response/GetMatchSummaryRes.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/dto/response/GetMatchSummaryRes.java
@@ -1,0 +1,25 @@
+package com.dnd.Exercise.domain.user.dto.response;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@Builder
+public class GetMatchSummaryRes {
+    @ApiModelProperty(value = "팀 매칭 참여 횟수")
+    private int teamMatchCount;
+
+    @ApiModelProperty(value = "1:1 매칭 참여 횟수")
+    private int duelMatchCount;
+
+    @ApiModelProperty(value = "매칭 안하는 팀 참여 횟수")
+    private int teamCount;
+
+    @ApiModelProperty(value = "매칭 승률 (소수점 첫째 자리에서 반올림)")
+    private int winningRate;
+}

--- a/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
@@ -61,6 +61,8 @@ public class User extends BaseEntity implements UserDetails {
 
     private Boolean isAppleLinked;
 
+    private Boolean isDeleted;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FcmToken> fcmTokens = new ArrayList<>();
 
@@ -112,6 +114,7 @@ public class User extends BaseEntity implements UserDetails {
         this.isNotificationAgreed = isNotificationAgreed;
         this.oauthId = oauthId;
         this.email = email;
+        this.isDeleted = false;
     }
 
     public void addToken(FcmToken fcmToken) {
@@ -138,4 +141,6 @@ public class User extends BaseEntity implements UserDetails {
     public void updatePassword(String password) {
         this.password = password;
     }
+
+    public void updateIsDeleted(Boolean isDeleted) { this.isDeleted = isDeleted; }
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/entity/User.java
@@ -144,5 +144,23 @@ public class User extends BaseEntity implements UserDetails {
 
     public void updateTeamworkRate(int teamworkRate) { this.teamworkRate = teamworkRate; }
 
-    public void updateIsDeleted(Boolean isDeleted) { this.isDeleted = isDeleted; }
+    public void setToWithdrawUser() {
+        this.age = 0;
+        this.email = null;
+        this.password = null;
+        this.height = 0;
+        this.weight = 0;
+        this.isAppleLinked = false;
+        this.isNotificationAgreed = false;
+        this.phoneNum = null;
+        this.profileImg = null;
+        this.skillLevel = null;
+        this.oauthId = null;
+        this.teamworkRate = 0;
+
+        this.uid = "unknown";
+        this.name = "알수없음";
+
+        this.isDeleted = true;
+    }
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/service/UserService.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.dnd.Exercise.domain.user.service;
 
 import com.dnd.Exercise.domain.user.dto.request.*;
+import com.dnd.Exercise.domain.user.dto.response.GetFinalSummaryRes;
 import com.dnd.Exercise.domain.user.dto.response.GetProfileDetail;
 
 public interface UserService {
@@ -11,4 +12,5 @@ public interface UserService {
     void updateAppleLinked(UpdateAppleLinkedReq updateAppleLinkedReq, long userId);
     void updateNotificationAgreed(UpdateNotificationAgreementReq updateNotificationAgreementReq, long userId);
     void withdraw(long userId);
+    GetFinalSummaryRes getFinalSummary(long userId);
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/service/UserService.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/service/UserService.java
@@ -2,6 +2,7 @@ package com.dnd.Exercise.domain.user.service;
 
 import com.dnd.Exercise.domain.user.dto.request.*;
 import com.dnd.Exercise.domain.user.dto.response.GetFinalSummaryRes;
+import com.dnd.Exercise.domain.user.dto.response.GetMatchSummaryRes;
 import com.dnd.Exercise.domain.user.dto.response.GetProfileDetail;
 
 public interface UserService {
@@ -13,4 +14,5 @@ public interface UserService {
     void updateNotificationAgreed(UpdateNotificationAgreementReq updateNotificationAgreementReq, long userId);
     void withdraw(long userId);
     GetFinalSummaryRes getFinalSummary(long userId);
+    GetMatchSummaryRes getMatchSummary(long userId);
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/service/UserService.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/service/UserService.java
@@ -10,4 +10,5 @@ public interface UserService {
     void updateProfile(UpdateMyProfileReq updateMyProfileReq, long userId);
     void updateAppleLinked(UpdateAppleLinkedReq updateAppleLinkedReq, long userId);
     void updateNotificationAgreed(UpdateNotificationAgreementReq updateNotificationAgreementReq, long userId);
+    void withdraw(long userId);
 }

--- a/src/main/java/com/dnd/Exercise/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/service/UserServiceImpl.java
@@ -1,12 +1,14 @@
 package com.dnd.Exercise.domain.user.service;
 
 import com.dnd.Exercise.domain.auth.service.AuthService;
+import com.dnd.Exercise.domain.exercise.repository.ExerciseRepository;
 import com.dnd.Exercise.domain.field.entity.Field;
 import com.dnd.Exercise.domain.field.entity.enums.FieldType;
 import com.dnd.Exercise.domain.field.repository.FieldRepository;
 import com.dnd.Exercise.domain.fieldEntry.repository.FieldEntryRepository;
 import com.dnd.Exercise.domain.user.dto.UserMapper;
 import com.dnd.Exercise.domain.user.dto.request.*;
+import com.dnd.Exercise.domain.user.dto.response.GetFinalSummaryRes;
 import com.dnd.Exercise.domain.user.dto.response.GetProfileDetail;
 import com.dnd.Exercise.domain.user.entity.User;
 import com.dnd.Exercise.domain.user.repository.UserRepository;
@@ -21,6 +23,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -35,6 +39,7 @@ public class UserServiceImpl implements UserService {
     private final UserFieldRepository userFieldRepository;
     private final FieldEntryRepository fieldEntryRepository;
     private final FieldRepository fieldRepository;
+    private final ExerciseRepository exerciseRepository;
 
     private final FieldUtil fieldUtil;
 
@@ -110,6 +115,23 @@ public class UserServiceImpl implements UserService {
 
         setToWithdrawUser(user);
         authService.logout(user.getId());
+    }
+
+    @Override
+    public GetFinalSummaryRes getFinalSummary(long userId) {
+        User user = getUser(userId);
+
+        int activeDays = Long.valueOf(ChronoUnit.DAYS.between(user.getCreatedAt(), LocalDateTime.now())).intValue();
+        int recordCounts = exerciseRepository.countByUserId(userId);
+        int matchCounts = userFieldRepository.countAllCompletedFieldsByUserId(userId);
+        int teamworkRate = user.getTeamworkRate();
+
+        return GetFinalSummaryRes.builder()
+                .activeDays(activeDays)
+                .recordCounts(recordCounts)
+                .matchCounts(matchCounts)
+                .teamworkRate(teamworkRate)
+                .build();
     }
 
     private User getUser(long userId) {

--- a/src/main/java/com/dnd/Exercise/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/service/UserServiceImpl.java
@@ -230,6 +230,8 @@ public class UserServiceImpl implements UserService {
         }
         else {
             exitOfMember(field,user);
+            fieldEntryRepository.deleteAllByHostField(field);
+            fieldEntryRepository.deleteAllByEntrantField(field);
         }
     }
 

--- a/src/main/java/com/dnd/Exercise/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/user/service/UserServiceImpl.java
@@ -1,17 +1,30 @@
 package com.dnd.Exercise.domain.user.service;
 
+import com.dnd.Exercise.domain.auth.service.AuthService;
+import com.dnd.Exercise.domain.field.entity.Field;
+import com.dnd.Exercise.domain.field.entity.enums.FieldType;
+import com.dnd.Exercise.domain.field.repository.FieldRepository;
+import com.dnd.Exercise.domain.fieldEntry.repository.FieldEntryRepository;
 import com.dnd.Exercise.domain.user.dto.UserMapper;
 import com.dnd.Exercise.domain.user.dto.request.*;
 import com.dnd.Exercise.domain.user.dto.response.GetProfileDetail;
 import com.dnd.Exercise.domain.user.entity.User;
 import com.dnd.Exercise.domain.user.repository.UserRepository;
+import com.dnd.Exercise.domain.userField.entity.UserField;
+import com.dnd.Exercise.domain.userField.repository.UserFieldRepository;
 import com.dnd.Exercise.global.error.dto.ErrorCode;
 import com.dnd.Exercise.global.error.exception.BusinessException;
 import com.dnd.Exercise.global.s3.AwsS3Service;
+import com.dnd.Exercise.global.util.field.FieldUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.dnd.Exercise.domain.field.entity.enums.FieldType.*;
 
 @Service
 @RequiredArgsConstructor
@@ -19,10 +32,17 @@ import org.springframework.web.multipart.MultipartFile;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
+    private final UserFieldRepository userFieldRepository;
+    private final FieldEntryRepository fieldEntryRepository;
+    private final FieldRepository fieldRepository;
+
+    private final FieldUtil fieldUtil;
 
     private final UserMapper userMapper;
 
     private final AwsS3Service awsS3Service;
+    private final AuthService authService;
+
     private final String S3_FOLDER = "user-profile";
 
     @Override
@@ -78,6 +98,20 @@ public class UserServiceImpl implements UserService {
         user.updateIsNotificationAgreed(updateNotificationAgreementReq.getIsNotificationAgreed());
     }
 
+    @Override
+    @Transactional
+    public void withdraw(long userId) {
+        User user = getUser(userId);
+
+        validateIsMatchingInProgress(user);
+
+        deleteMyEntrantRequest(user);
+        exitBeforeProgressFields(user);
+
+        setToWithdrawUser(user);
+        authService.logout(user.getId());
+    }
+
     private User getUser(long userId) {
         return userRepository.findById(userId).get();
     }
@@ -107,5 +141,79 @@ public class UserServiceImpl implements UserService {
         if(fileName != null) {
             awsS3Service.deleteImage(fileName);
         }
+    }
+
+    private void validateIsMatchingInProgress(User user) {
+        List<UserField> myUserFields = userFieldRepository.findAllByUser(user);
+
+        myUserFields.forEach(myUserField -> {
+            Field myField = myUserField.getField();
+            if (fieldUtil.isFieldInProgress(myField)) {
+                throw new BusinessException(ErrorCode.CANNOT_WITHDRAW_WHILE_IN_MATCH);
+            }
+        });
+    }
+
+    private void deleteMyEntrantRequest(User user) {
+        fieldEntryRepository.deleteAllByEntrantUser(user);
+    }
+
+    private void exitBeforeProgressFields(User user) {
+        List<UserField> beforeProgressUserFields = userFieldRepository.findAllBeforeProgressFieldByUser(user);
+        List<Field> beforeProgressFields = beforeProgressUserFields.stream().map(UserField::getField).collect(Collectors.toList());
+
+        beforeProgressFields.forEach(field -> {
+            FieldType fieldType = field.getFieldType();
+            if (fieldType == DUEL) {
+                deleteFieldAndEntries(field,user);
+            }
+            else {
+                exitField(field,user);
+            }
+        });
+    }
+
+    private void deleteFieldAndEntries(Field field, User user) {
+        long fieldId = field.getId();
+        fieldEntryRepository.deleteAllByEntrantField(field);
+        fieldEntryRepository.deleteAllByHostField(field);
+        userFieldRepository.deleteByFieldAndUser(field,user);
+        fieldRepository.deleteById(fieldId);
+    }
+
+    private void exitField(Field field, User user) {
+        if (user.getId() == field.getLeaderId()) {
+            exitOfLeader(field,user);
+        }
+        else {
+            exitOfMember(field,user);
+        }
+    }
+
+    private void exitOfLeader(Field field, User user) {
+        long fieldId = field.getId();
+
+        if (field.getCurrentSize() > 1) {
+            throw new BusinessException(ErrorCode.SELECT_LEADER_BEFORE_WITHDRAW);
+        }
+
+        if (field.getFieldType() == TEAM_BATTLE) {
+            fieldEntryRepository.deleteAllByEntrantField(field);
+            fieldEntryRepository.deleteAllByHostField(field);
+        }
+        userFieldRepository.deleteByFieldAndUser(field,user);
+        fieldRepository.deleteById(fieldId);
+    }
+
+    private void exitOfMember(Field field, User user) {
+        userFieldRepository.deleteByFieldAndUser(field,user);
+        field.subtractMember();
+    }
+
+    private void setToWithdrawUser(User user) {
+        if (user.getProfileImg() != null) {
+            awsS3Service.deleteImage(user.getProfileImg());
+        }
+        user.setToWithdrawUser();
     }
 }

--- a/src/main/java/com/dnd/Exercise/domain/userField/repository/UserFieldRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/repository/UserFieldRepository.java
@@ -64,4 +64,11 @@ public interface UserFieldRepository extends JpaRepository<UserField, Long>, Use
             "where uf.user.id = :userId " +
                 "and uf.field.fieldStatus = 'COMPLETED'")
     int countAllCompletedFieldsByUserId(long userId);
+
+    @Query("select count(uf) " +
+            "from UserField uf " +
+            "where uf.user.id = :userId " +
+                "and uf.field.fieldType in :fieldType " +
+                "and uf.field.fieldStatus = 'COMPLETED'")
+    int countCompletedFieldsByUserIdAndFieldType(long userId, List<FieldType> fieldType);
 }

--- a/src/main/java/com/dnd/Exercise/domain/userField/repository/UserFieldRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/repository/UserFieldRepository.java
@@ -51,4 +51,11 @@ public interface UserFieldRepository extends JpaRepository<UserField, Long>, Use
             "where uf.user = :user " +
             "and uf.field.fieldStatus = :fieldStatus")
     List<UserField> findAllByUserAndFieldStatus(User user, FieldStatus fieldStatus);
+
+    @Query("select uf " +
+            "from UserField uf join fetch uf.field " +
+            "where uf.user = :user " +
+                "and uf.field.fieldStatus = 'RECRUITING' " +
+                "and uf.field.opponent = null")
+    List<UserField> findAllBeforeProgressFieldByUser(User user);
 }

--- a/src/main/java/com/dnd/Exercise/domain/userField/repository/UserFieldRepository.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/repository/UserFieldRepository.java
@@ -58,4 +58,10 @@ public interface UserFieldRepository extends JpaRepository<UserField, Long>, Use
                 "and uf.field.fieldStatus = 'RECRUITING' " +
                 "and uf.field.opponent = null")
     List<UserField> findAllBeforeProgressFieldByUser(User user);
+
+    @Query("select count(uf) " +
+            "from UserField uf " +
+            "where uf.user.id = :userId " +
+                "and uf.field.fieldStatus = 'COMPLETED'")
+    int countAllCompletedFieldsByUserId(long userId);
 }

--- a/src/main/java/com/dnd/Exercise/domain/userField/service/UserFieldServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/service/UserFieldServiceImpl.java
@@ -237,6 +237,7 @@ public class UserFieldServiceImpl implements UserFieldService {
             throw new BusinessException(MUST_NOT_LEADER);
         }
         userFieldRepository.deleteByFieldAndUser(field, user);
+        field.subtractMember();
     }
 
     @Transactional

--- a/src/main/java/com/dnd/Exercise/domain/userField/service/UserFieldServiceImpl.java
+++ b/src/main/java/com/dnd/Exercise/domain/userField/service/UserFieldServiceImpl.java
@@ -23,6 +23,7 @@ import com.dnd.Exercise.domain.field.entity.enums.BattleType;
 import com.dnd.Exercise.domain.field.entity.Field;
 import com.dnd.Exercise.domain.field.entity.enums.FieldType;
 import com.dnd.Exercise.domain.field.entity.enums.RankCriterion;
+import com.dnd.Exercise.domain.fieldEntry.repository.FieldEntryRepository;
 import com.dnd.Exercise.domain.notification.entity.NotificationDto;
 import com.dnd.Exercise.domain.notification.entity.NotificationTopic;
 import com.dnd.Exercise.domain.notification.event.NotificationEvent;
@@ -64,6 +65,7 @@ public class UserFieldServiceImpl implements UserFieldService {
     private final ExerciseRepository exerciseRepository;
     private final ActivityRingRepository activityRingRepository;
     private final UserRepository userRepository;
+    private final FieldEntryRepository fieldEntryRepository;
     private final FieldUtil fieldUtil;
     private final ApplicationEventPublisher eventPublisher;
     private final RedisService redisService;
@@ -238,6 +240,8 @@ public class UserFieldServiceImpl implements UserFieldService {
         }
         userFieldRepository.deleteByFieldAndUser(field, user);
         field.subtractMember();
+        fieldEntryRepository.deleteAllByHostField(field);
+        fieldEntryRepository.deleteAllByEntrantField(field);
     }
 
     @Transactional

--- a/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
+++ b/src/main/java/com/dnd/Exercise/global/error/dto/ErrorCode.java
@@ -88,6 +88,10 @@ public enum ErrorCode {
 
     NEED_CALORIE_GOAL(HttpStatus.BAD_REQUEST, "U-002", "애플 연동 유저인 경우 목표 칼로리 값을 전송해야 합니다."),
 
+    CANNOT_WITHDRAW_WHILE_IN_MATCH(HttpStatus.BAD_REQUEST, "U-003", "진행 중인 매칭이 완료된 후에 탈퇴해 주세요."),
+
+    SELECT_LEADER_BEFORE_WITHDRAW(HttpStatus.BAD_REQUEST, "U-004", "내가 속한 팀의 방장을 누군가에게 넘긴 후 탈퇴해 주세요."),
+
     UPLOAD_FAILED(HttpStatus.BAD_REQUEST, "S-001", "업로드 중 오류가 발생했습니다."),
 
     FILE_DELETE_FAILED(HttpStatus.BAD_REQUEST, "S-002", "파일 삭제 중 오류가 발생했습니다."),

--- a/src/main/java/com/dnd/Exercise/global/util/field/FieldUtil.java
+++ b/src/main/java/com/dnd/Exercise/global/util/field/FieldUtil.java
@@ -16,6 +16,7 @@ import com.dnd.Exercise.domain.activityRing.repository.ActivityRingRepository;
 import com.dnd.Exercise.domain.exercise.entity.Exercise;
 import com.dnd.Exercise.domain.exercise.repository.ExerciseRepository;
 import com.dnd.Exercise.domain.field.entity.Field;
+import com.dnd.Exercise.domain.field.entity.enums.FieldStatus;
 import com.dnd.Exercise.domain.field.entity.enums.FieldType;
 import com.dnd.Exercise.domain.field.entity.enums.WinStatus;
 import com.dnd.Exercise.domain.field.repository.FieldRepository;
@@ -155,4 +156,11 @@ public class FieldUtil {
         return userField.get(0);
     }
 
+    public Boolean isFieldInProgress(Field field) {
+        if (field.getFieldStatus() == FieldStatus.IN_PROGRESS ||
+                (field.getFieldStatus() == FieldStatus.RECRUITING && field.getOpponent() != null)) {
+            return true;
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
## 🧑🏻‍💻 PR 작업 내역 요약
마이페이지 관련 API 를 구현합니다.
- 회원 탈퇴
- 탈퇴 전 유저의 활동내역 조회
- 마이페이지 나의 활동내역(매칭 횟수, 승률) 조회
- 현재 연결된 계정 확인

## 📋 변경 사항
- `UserController`
    - `withdraw`
    - `getFinalSummary`
    - `getMatchSummary`
    - `getConnectedAccount`

## 🔍 Code Review
- FieldUtil 에 '진행 중인 매칭' 인지 판단하는 함수 추가하였습니다. 📍관련커밋: ade87db
    - FieldUtil - `isFieldInProgress()`
- '회원 탈퇴' 를 구현하던 도중 '팀 나가기' 부분을 검토하다가 수정한 부분입니다..!
  - '팀 나가기' 시에 팀의 인원 수를 -1 해주는 부분이 빠진 것 같아 추가하였습니다! 📍관련 커밋: d766a05
  - 누군가 팀을 나간다면, 인원을 추가로 모은 뒤에 매칭을 시작할 수 있으므로 해당 팀이 기존에(팀원이 나가기 전에) 신청해뒀던/신청받은 매칭 내역들이 더이상 유효하지 않게 되기에, 기존 신청 내역들을 삭제해 주어야 하나? 라는 의문이 들었습니다..! 그런데 누가 한명 나갔다고 해서 해당 내역들이 모두 사라지는 것도 이상한 것 같아, 내역들은 그대로 남기되 '매칭 수락' 직전에 entrantField, hostField 모두 인원이 full 인지 한번 더 확인해 주도록 하였습니다..! 📍관련 커밋: 7950183
  (혹시 다른 좋은 방법이 생각나시면 리뷰 부탁드립니다..! 🙏🏻🙇🏻‍♀️)

## 📸 ScreenShot

## 연결된 이슈 Close
close #95 
